### PR TITLE
add autoYaml test

### DIFF
--- a/pkg/action/build_test.go
+++ b/pkg/action/build_test.go
@@ -119,3 +119,33 @@ func TestBuildReleasesMatchGroups(t *testing.T) {
 		t.Error("'redis-b' not found")
 	}
 }
+
+func TestBuildAutoYml(t *testing.T) {
+	defer clean()
+
+	y := &Yml{
+		tests.Root + "01_helmwave.yml.tpl",
+		tests.Root + "01_auto_yaml_helmwave.yml",
+	}
+
+	s := &Build{
+		plandir:  tests.Root + plan.Dir,
+		tags:     cli.StringSlice{},
+		matchAll: true,
+		autoYml:  true,
+		yml:      y,
+	}
+
+	value := "Test01"
+	_ = os.Setenv("PROJECT_NAME", value)
+	_ = os.Setenv("NAMESPACE", value)
+
+	err := s.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if ok := helper.IsExists(tests.Root + plan.Dir + plan.Manifest); !ok {
+		t.Error(plan.ErrManifestDirNotFound)
+	}
+}


### PR DESCRIPTION
```
=== RUN   TestBuildAutoYml
time="2021-09-18T23:09:12+03:00" level=info msg="📄 YML is ready!" build plan with next command="helmwave build"
time="2021-09-18T23:09:12+03:00" level=info msg="Building releases..."
time="2021-09-18T23:09:12+03:00" level=info msg="Building graphs..."
time="2021-09-18T23:09:12+03:00" level=info msg="Depends On:\n┌───────────────┐\n│ nginx@Test01  │\n└───────────────┘\n"
time="2021-09-18T23:09:12+03:00" level=info msg="Building values..."
time="2021-09-18T23:09:12+03:00" level=info msg="✅ nginx@Test01 values count 0" values="[]"
time="2021-09-18T23:09:12+03:00" level=info msg="Building repositories..."
time="2021-09-18T23:09:12+03:00" level=info msg="🗄 \"bitnami\" has been added to the plan"
time="2021-09-18T23:09:12+03:00" level=info msg="❎  \"bitnami\" already exists with the same configuration, skipping"
time="2021-09-18T23:09:12+03:00" level=warning msg="⚠️ looks like https://kubernetes-charts.storage.googleapis.com is not a valid chart repository or cannot be reached"
time="2021-09-18T23:09:12+03:00" level=info msg="Building manifests..."
time="2021-09-18T23:09:12+03:00" level=warning msg="❌ nginx@Test01 cant get dependencies : could not find bitnami/nginx: stat bitnami/nginx: no such file or directory"
time="2021-09-18T23:09:26+03:00" level=info msg="✅ nginx@Test01 manifest done"
time="2021-09-18T23:09:26+03:00" level=info msg="🏗 Plan" releases="[nginx@Test01]" repositories="[stable bitnami]"
time="2021-09-18T23:09:26+03:00" level=info msg="🏗 Planfile is ready!" deploy it with next command="helmwave up --plandir ../../tests/.helmwave/"
--- PASS: TestBuildAutoYml (14.70s)
PASS
```
