### PR TITLE
update goreleaser build option

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ dockers:
     - "--target=scratch-goreleaser"
     goos: linux
     goarch: amd64
-    use_buildx: true
+    use: buildx
   - dockerfile: Dockerfile
     image_templates:
       - "ghcr.io/helmwave/helmwave:{{ .Version }}"
@@ -92,7 +92,7 @@ dockers:
       - "--target=goreleaser"
     goos: linux
     goarch: amd64
-    use_buildx: true
+    use: buildx
 
 brews:
   - tap:


### PR DESCRIPTION
remove deprecation notice: https://goreleaser.com/deprecations/#dockeruse_buildx
```
      • docker images    
            • DEPRECATED: `docker.use_buildx` should not be used anymore, check https://goreleaser.com/deprecations#dockerusebuildx for more info
            • DEPRECATED: `docker.use_buildx` should not be used anymore, check https://goreleaser.com/deprecations#dockerusebuildx for more info
```