### PR TITLE
Tune goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches:
       - main
-      - '!dependabot/*'
     types:
       - closed
   push:
     tags: ['*']
+
+permissions:
+  contents: write
+  packages: write
+  issues: write
 
 jobs:
   tagger:
@@ -77,7 +81,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -90,7 +94,7 @@ jobs:
           go-version: 1.17
 
       - name: Cache Go modules
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -103,4 +107,5 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.CR_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.CR_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
       - darwin
     ignore:
       - goos: darwin
-        goarch: 386
+        goarch: "386"
     main: ./cmd/helmwave
     ldflags:
       - -s -w -X github.com/helmwave/helmwave/pkg/version.Version={{.Version}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,16 +34,30 @@ release:
   prerelease: auto
 
 changelog:
+  skip: false
+  use: github
   sort: asc
+
+  groups:
+    - title: "Linter"
+      regexp: "^.*linter.*$"
+      order: 0
+    - title: "Tests"
+      regexp: "^.*tests?.*$"
+      order: 1
+    - title: "Documentation"
+      regexp: "^.*(documentation|docs?).*$"
+      order: 2
+    - title: "Other"
+      order: 999
+
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
       - '^WIP:'
       - Merge pull request
       - Merge branch
       - go mod tidy
-
+      - typo
 
 dockers:
   - dockerfile: Dockerfile
@@ -98,8 +112,15 @@ brews:
   - tap:
       owner: helmwave
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     description: "HelmWave is like docker-compose for helm"
     license: "MIT"
     folder: formula
 
-
+milestones:
+  - repo:
+      owner: helmwave
+      name: helmwave
+    close: true
+    fail_on_error: false
+    name_template: "{{.Tag}}"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.buildTags": "integration"
+}


### PR DESCRIPTION
* Reduce permissions for github token
* Use custom token only for homebrew tap updates
* Group up commits in changelog
* Automatically close milestones on release