### PR TITLE
Add charts cache for build command

### DIFF
--- a/.changes/unreleased/New feature-20230202-175721.yaml
+++ b/.changes/unreleased/New feature-20230202-175721.yaml
@@ -1,0 +1,6 @@
+kind: New feature
+body: Add support for charts caching in build command
+time: 2023-02-02T17:57:21.428300345+03:00
+custom:
+  Author: DemitrSpb
+  Issue: ""

--- a/pkg/action/build.go
+++ b/pkg/action/build.go
@@ -43,7 +43,10 @@ func (i *Build) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	cache.ChartsCache.Init(i.chartsCacheDir)
+	err = cache.ChartsCache.Init(i.chartsCacheDir)
+	if err != nil {
+		return err
+	}
 
 	newPlan := plan.New(i.plandir)
 	err = newPlan.Build(ctx, i.yml.file, i.normalizeTags(), i.matchAll, i.yml.templater)

--- a/pkg/action/build.go
+++ b/pkg/action/build.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/helmwave/helmwave/pkg/cache"
 	"github.com/helmwave/helmwave/pkg/plan"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -12,13 +13,14 @@ import (
 
 // Build is struct for running 'build' CLI command.
 type Build struct {
-	yml      *Yml
-	diff     *Diff
-	plandir  string
-	diffMode string
-	tags     cli.StringSlice
-	matchAll bool
-	autoYml  bool
+	yml            *Yml
+	diff           *Diff
+	plandir        string
+	diffMode       string
+	chartsCacheDir string
+	tags           cli.StringSlice
+	matchAll       bool
+	autoYml        bool
 
 	// diffLive *DiffLive
 	// diffLocal *DiffLocalPlan
@@ -40,6 +42,8 @@ func (i *Build) Run(ctx context.Context) (err error) {
 			return err
 		}
 	}
+
+	cache.ChartsCache.Init(i.chartsCacheDir)
 
 	newPlan := plan.New(i.plandir)
 	err = newPlan.Build(ctx, i.yml.file, i.normalizeTags(), i.matchAll, i.yml.templater)
@@ -103,6 +107,7 @@ func (i *Build) flags() []cli.Flag {
 		flagTags(&i.tags),
 		flagMatchAllTags(&i.matchAll),
 		flagDiffMode(&i.diffMode),
+		flagChartsCacheDir(&i.chartsCacheDir),
 
 		&cli.BoolFlag{
 			Name:        "yml",

--- a/pkg/action/flags.go
+++ b/pkg/action/flags.go
@@ -133,7 +133,7 @@ func flagChartsCacheDir(v *string) *cli.StringFlag {
 		Name:        "charts-cache-dir",
 		Value:       "",
 		Usage:       "Enable caching of helm charts in specified directory",
-		EnvVars:     []string{"HELMWAVE_CHARTS_CACHE_DIR"},
+		EnvVars:     []string{"HELMWAVE_CHARTS_CACHE"},
 		Destination: v,
 	}
 }

--- a/pkg/action/flags.go
+++ b/pkg/action/flags.go
@@ -126,3 +126,14 @@ func flagDiffThreeWayMerge(v *bool) *cli.BoolFlag {
 		Destination: v,
 	}
 }
+
+// flagDiffMode pass val to urfave flag.
+func flagChartsCacheDir(v *string) *cli.StringFlag {
+	return &cli.StringFlag{
+		Name:        "charts-cache-dir",
+		Value:       "",
+		Usage:       "Enable caching of helm charts in specified directory",
+		EnvVars:     []string{"HELMWAVE_CHARTS_CACHE_DIR"},
+		Destination: v,
+	}
+}

--- a/pkg/cache/charts_cache.go
+++ b/pkg/cache/charts_cache.go
@@ -3,7 +3,9 @@ package cache
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"sync"
 
 	"github.com/helmwave/helmwave/pkg/helper"
 	log "github.com/sirupsen/logrus"
@@ -14,10 +16,21 @@ var ChartsCache = CacheConfig{}
 
 type CacheConfig struct {
 	cacheDir string
+	lock     sync.RWMutex
 }
 
-func (c *CacheConfig) Init(dir string) {
+func (c *CacheConfig) Init(dir string) error {
 	c.cacheDir = dir
+	if dir == "" {
+		return nil
+	}
+	if !helper.IsExists(dir) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create cache directory %s: %w", dir, err)
+		}
+	}
+
+	return nil
 }
 
 func (c *CacheConfig) IsEnabled() bool {
@@ -30,7 +43,7 @@ func (c *CacheConfig) FindInCache(chart string, version string) (string, error) 
 	}
 
 	chartName := filepath.Base(chart)
-	chartFile := fmt.Sprintf("%s/%s-%s.tgz", c.cacheDir, chartName, version)
+	chartFile := path.Join(c.cacheDir, fmt.Sprintf("%s-%s.tgz", chartName, version))
 
 	_, err := os.Stat(chartFile)
 	if err == nil {
@@ -44,6 +57,8 @@ func (c *CacheConfig) AddToCache(file string) {
 	if !c.IsEnabled() {
 		return
 	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
 
 	if err := helper.CopyFile(file, c.cacheDir); err != nil {
 		log.Warn(fmt.Errorf("failed to cache chart %s: %w", file, err))

--- a/pkg/cache/charts_cache.go
+++ b/pkg/cache/charts_cache.go
@@ -45,6 +45,9 @@ func (c *CacheConfig) FindInCache(chart string, version string) (string, error) 
 	chartName := filepath.Base(chart)
 	chartFile := path.Join(c.cacheDir, fmt.Sprintf("%s-%s.tgz", chartName, version))
 
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	_, err := os.Stat(chartFile)
 	if err == nil {
 		return chartFile, nil

--- a/pkg/cache/charts_cache.go
+++ b/pkg/cache/charts_cache.go
@@ -1,0 +1,51 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/helmwave/helmwave/pkg/helper"
+	log "github.com/sirupsen/logrus"
+)
+
+//nolint:gochecknoglobals
+var ChartsCache = CacheConfig{}
+
+type CacheConfig struct {
+	cacheDir string
+}
+
+func (c *CacheConfig) Init(dir string) {
+	c.cacheDir = dir
+}
+
+func (c *CacheConfig) IsEnabled() bool {
+	return c.cacheDir != ""
+}
+
+func (c *CacheConfig) FindInCache(chart string, version string) (string, error) {
+	if !c.IsEnabled() {
+		return "", fmt.Errorf("cache is disabled")
+	}
+
+	chartName := filepath.Base(chart)
+	chartFile := fmt.Sprintf("%s/%s-%s.tgz", c.cacheDir, chartName, version)
+
+	_, err := os.Stat(chartFile)
+	if err == nil {
+		return chartFile, nil
+	}
+
+	return "", fmt.Errorf("chart not found")
+}
+
+func (c *CacheConfig) AddToCache(file string) {
+	if !c.IsEnabled() {
+		return
+	}
+
+	if err := helper.CopyFile(file, c.cacheDir); err != nil {
+		log.Warn(fmt.Errorf("failed to cache chart %s: %w", file, err))
+	}
+}

--- a/pkg/cache/charts_cache.go
+++ b/pkg/cache/charts_cache.go
@@ -45,8 +45,8 @@ func (c *CacheConfig) FindInCache(chart string, version string) (string, error) 
 	chartName := filepath.Base(chart)
 	chartFile := path.Join(c.cacheDir, fmt.Sprintf("%s-%s.tgz", chartName, version))
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
 	_, err := os.Stat(chartFile)
 	if err == nil {

--- a/pkg/helper/file.go
+++ b/pkg/helper/file.go
@@ -2,10 +2,11 @@ package helper
 
 import (
 	"fmt"
-	"io"
 	"os"
+	"path"
 	"path/filepath"
 
+	cp "github.com/otiai10/copy"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -53,45 +54,15 @@ func IsExists(s string) bool {
 
 // CopyFile copy file to dest. Destination is either file or dir.
 func CopyFile(src, dest string) error {
-	fin, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("failed to open file %s: %w", src, err)
-	}
-	defer func() {
-		e := fin.Close()
-		// Report the error from Close, if any.
-		// But do so only if there isn't already
-		// an outgoing error.
-		if e != nil && err == nil {
-			err = e
-		}
-	}()
-
 	destStat, err := os.Stat(dest)
-	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", dest, err)
-	}
 
-	// if destination is directory, add file name
-	if destStat.Mode().IsDir() {
-		dest = fmt.Sprintf("%s/%s", dest, filepath.Base(src))
-	}
-
-	fout, err := CreateFile(dest)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		e := fout.Close()
-		if e != nil && err == nil {
-			err = e
+	if err == nil {
+		if destStat.Mode().IsDir() {
+			dest = path.Join(dest, filepath.Base(src))
+		} else {
+			return fmt.Errorf("failed to copy file '%s': destination '%s' already exists", src, dest)
 		}
-	}()
-
-	_, copyErr := io.Copy(fout, fin)
-	if copyErr != nil {
-		return fmt.Errorf("failed to copy file %s: %w", src, copyErr)
 	}
 
-	return err
+	return cp.Copy(src, dest)
 }

--- a/pkg/helper/file.go
+++ b/pkg/helper/file.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -48,4 +49,49 @@ func IsExists(s string) bool {
 
 		return false
 	}
+}
+
+// CopyFile copy file to dest. Destination is either file or dir.
+func CopyFile(src, dest string) error {
+	fin, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open file %s: %w", src, err)
+	}
+	defer func() {
+		e := fin.Close()
+		// Report the error from Close, if any.
+		// But do so only if there isn't already
+		// an outgoing error.
+		if e != nil && err == nil {
+			err = e
+		}
+	}()
+
+	destStat, err := os.Stat(dest)
+	if err != nil {
+		return fmt.Errorf("failed to stat %s: %w", dest, err)
+	}
+
+	// if destination is directory, add file name
+	if destStat.Mode().IsDir() {
+		dest = fmt.Sprintf("%s/%s", dest, filepath.Base(src))
+	}
+
+	fout, err := CreateFile(dest)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		e := fout.Close()
+		if e != nil && err == nil {
+			err = e
+		}
+	}()
+
+	_, copyErr := io.Copy(fout, fin)
+	if copyErr != nil {
+		return fmt.Errorf("failed to copy file %s: %w", src, copyErr)
+	}
+
+	return err
 }

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -69,6 +69,7 @@ func (p *Plan) Build(ctx context.Context, yml string, tags []string, matchAll bo
 
 	// to build charts we need repositories and registries first
 	log.Info("Building charts...")
+
 	err = p.buildCharts()
 	if err != nil {
 		return err


### PR DESCRIPTION
Добавил опцию --charts-cache-dir для build команды
Включает кэширование хелм-чартов в указанной директории
- берет чарт из этого кэша, если там есть.
- иначе скачивает и добавляет в кэш

Это понадобилось для того, чтобы после build иметь все необходимые артефакты в папочке, которую можно перенести в закрытый контур и там развернуть без доступа к репозиториям.

Есть, конечно, костыль через темплэйт и переменные типа USE_LOCAL_CACHE=1
```
{{ if eq USE_LOCAL_CACHE 1 }}
chart: cache/chart-1.0.0.tgz
{{ else }}
chart:
  name: repo/chart
  version: 1.0.0
{{ end }}  
```
Но этот подход оказался не удобный в использовании и сложно поддерживаемый в CI

Как бонус, при использовании кэша пропадает два лишних скачивания чарта: в buildReleaseManifest и в DiffLive