### PR TITLE
✨  feat: create a new debug tag for docker image with extra tools for hook/lifecycle command usages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -144,6 +144,53 @@ dockers:
     goos: linux
     goarch: arm64
     use: buildx
+  - dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/helmwave/helmwave:{{ .Version }}-debug-amd64
+      - ghcr.io/helmwave/helmwave:debug-amd64
+      - diamon/helmwave:{{ .Version }}-debug-amd64
+      - diamon/helmwave:debug-amd64
+    build_flag_templates:
+      - "--label=org.opencontainers.image.description=Helmwave is tool for deploy your Helm Charts via GitOps"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+      - "--label=org.opencontainers.image.source=https://github.com/helmwave/helmwave"
+      - "--label=org.opencontainers.image.url=https://github.com/helmwave/helmwave/pkgs/container/helmwave"
+      - "--label=org.opencontainers.image.documentation=https://helmwave.github.io/docs/"
+
+      - "--platform=linux/amd64"
+      - "--target=debug-goreleaser"
+      - "--pull"
+    goos: linux
+    goarch: amd64
+    goamd64: v1
+    use: buildx
+  - dockerfile: Dockerfile
+    image_templates:
+      - ghcr.io/helmwave/helmwave:{{ .Version }}-debug-arm64v8
+      - ghcr.io/helmwave/helmwave:debug-arm64v8
+      - diamon/helmwave:{{ .Version }}-debug-arm64v8
+      - diamon/helmwave:debug-arm64v8
+    build_flag_templates:
+      - "--label=org.opencontainers.image.description=Helmwave is tool for deploy your Helm Charts via GitOps"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+      - "--label=org.opencontainers.image.source=https://github.com/helmwave/helmwave"
+      - "--label=org.opencontainers.image.url=https://github.com/helmwave/helmwave/pkgs/container/helmwave"
+      - "--label=org.opencontainers.image.documentation=https://helmwave.github.io/docs/"
+
+      - "--platform=linux/arm64/v8"
+      - "--target=debug-goreleaser"
+      - "--pull"
+    goos: linux
+    goarch: arm64
+    use: buildx
 
 docker_manifests:
   - name_template: ghcr.io/helmwave/helmwave:{{ .Version }}-scratch
@@ -178,6 +225,23 @@ docker_manifests:
     image_templates:
       - diamon/helmwave:latest-amd64
       - diamon/helmwave:latest-arm64v8
+  - name_template: ghcr.io/helmwave/helmwave:{{ .Version }}-debug
+    image_templates:
+      - ghcr.io/helmwave/helmwave:{{ .Version }}-debug-amd64
+      - ghcr.io/helmwave/helmwave:{{ .Version }}-debug-arm64v8
+  - name_template: ghcr.io/helmwave/helmwave:latest
+    image_templates:
+      - ghcr.io/helmwave/helmwave:debug-amd64
+      - ghcr.io/helmwave/helmwave:debug-arm64v8
+  - name_template: diamon/helmwave:{{ .Version }}-debug
+    image_templates:
+      - diamon/helmwave:{{ .Version }}-debug-amd64
+      - diamon/helmwave:{{ .Version }}-debug-arm64v8
+  - name_template: diamon/helmwave:debug
+    image_templates:
+      - diamon/helmwave:debug-amd64
+      - diamon/helmwave:debug-arm64v8
+
 
 ###
 # Publishes

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN go build -a -o /${PROJECT} ./cmd/${PROJECT}
 FROM alpine:${ALPINE_VERSION} as base-release
 RUN apk --update --no-cache add ca-certificates && update-ca-certificates
 COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /bin/kubectl
+RUN chown root:root /bin/kubectl && \
+	chmod 0755 /bin/kubectl
 ENTRYPOINT ["/bin/helmwave"]
 
 ### Build with goreleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,21 @@ RUN go build -a -o /${PROJECT} ./cmd/${PROJECT}
 ### Base image with shell
 FROM alpine:${ALPINE_VERSION} as base-release
 RUN apk --update --no-cache add ca-certificates && update-ca-certificates
+ENTRYPOINT ["/bin/helmwave"]
+
+### Base image with shell and debugging tools
+FROM alpine:${ALPINE_VERSION} as base-debug-release
+RUN apk --update --no-cache add ca-certificates jq bash &&\
+	update-ca-certificates
 COPY --chown=root:root --chmod=0775 --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /bin/kubectl
 ENTRYPOINT ["/bin/helmwave"]
 
 ### Build with goreleaser
 FROM base-release as goreleaser
+COPY helmwave /bin/
+
+### Debug tag
+FROM base-debug-release as debug-goreleaser
 COPY helmwave /bin/
 
 ### Build in docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,7 @@ RUN go build -a -o /${PROJECT} ./cmd/${PROJECT}
 ### Base image with shell
 FROM alpine:${ALPINE_VERSION} as base-release
 RUN apk --update --no-cache add ca-certificates && update-ca-certificates
-COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /bin/kubectl
-RUN chown root:root /bin/kubectl && \
-	chmod 0755 /bin/kubectl
+COPY --chown=root:root --chmod=0775 --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /bin/kubectl
 ENTRYPOINT ["/bin/helmwave"]
 
 ### Build with goreleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN go build -a -o /${PROJECT} ./cmd/${PROJECT}
 ### Base image with shell
 FROM alpine:${ALPINE_VERSION} as base-release
 RUN apk --update --no-cache add ca-certificates && update-ca-certificates
+COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /bin/kubectl
 ENTRYPOINT ["/bin/helmwave"]
 
 ### Build with goreleaser


### PR DESCRIPTION
For usages like hook scrips, etc. `kubectl` command is a common thing to have (specially in CI/CD Platforms)

Bitnami's base image has support for both amd64 and arm64 (see https://hub.docker.com/r/bitnami/kubectl/tags) so, it should be OK