### PR TITLE
Fix cached chart with relative path in URL not selected during build

### DIFF
--- a/.changes/unreleased/Fixed-20240815-133339.yaml
+++ b/.changes/unreleased/Fixed-20240815-133339.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix cached chart with relative path in URL not selected during build
+time: 2024-08-15T13:33:39.233042343Z
+custom:
+    Author: Vigilans
+    Issue: "936"


### PR DESCRIPTION
Closes https://github.com/helmwave/helmwave/issues/936

Note: this fix is not so optimal, because the logic to fetch base url is already done in `rel.getDownloader.ResolveChartVersion`. That means, with this PR's patch helm repository config file (`~/.config/helm/repository.yaml`) will be read twice with `findChartInHelmCache`. Unfortunately, helm's downloader does not expose any API to reuse the loaded repo data.

A more simpler fix would be to replace `slices.Contains`' (which is exact match) with `strings.HasSuffix` test. 