### PR TITLE
Fix release-scope build lifecycle hook

### DIFF
--- a/.changes/unreleased/Fixed-20240815-133106.yaml
+++ b/.changes/unreleased/Fixed-20240815-133106.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Fix release-scope build lifecycle hook
+time: 2024-08-15T13:31:06.514344721Z
+custom:
+    Author: Vigilans
+    Issue: "935"

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -50,7 +50,7 @@ func (p *Plan) build(ctx context.Context, o BuildOptions) error {
 	var err error
 
 	log.Info("🔨 Building releases...")
-	p.body.Releases, err = p.buildReleases(o)
+	p.body.Releases, err = p.buildReleases(ctx, o)
 	if err != nil {
 		return err
 	}

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -34,21 +34,21 @@ func (p *Plan) Build(ctx context.Context, o BuildOptions) (err error) {
 	}
 
 	defer func() {
-		lifeCycleErr := p.body.Lifecycle.RunPostBuild(ctx)
-		if lifeCycleErr != nil {
-			log.Errorf("got an error from postbuild hooks: %v", lifeCycleErr)
+		lifecycleErr := p.body.Lifecycle.RunPostBuild(ctx)
+		if lifecycleErr != nil {
+			log.Errorf("got an error from postbuild hooks: %v", lifecycleErr)
 			if err == nil {
-				err = lifeCycleErr
+				err = lifecycleErr
 			}
 			return
 		}
 		for _, r := range p.body.Releases {
-			lifeCycle := r.LifeCycle()
-			lifeCycleErr = lifeCycle.RunPostBuild(ctx)
-			if lifeCycleErr != nil {
-				log.Errorf("got an error from postbuild hooks for release %s: %v", r.Name(), lifeCycleErr)
+			lifecycle := r.Lifecycle()
+			lifecycleErr = lifecycle.RunPostBuild(ctx)
+			if lifecycleErr != nil {
+				log.Errorf("got an error from postbuild hooks for release %s: %v", r.Name(), lifecycleErr)
 				if err == nil {
-					err = lifeCycleErr
+					err = lifecycleErr
 				}
 				return
 			}

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -34,14 +34,7 @@ func (p *Plan) Build(ctx context.Context, o BuildOptions) (err error) {
 	}
 
 	defer func() {
-		lifecycleErr := p.body.Lifecycle.RunPostBuild(ctx)
-		if lifecycleErr != nil {
-			log.Errorf("got an error from postbuild hooks: %v", lifecycleErr)
-			if err == nil {
-				err = lifecycleErr
-			}
-			return
-		}
+		var lifecycleErr error
 		for _, r := range p.body.Releases {
 			lifecycle := r.Lifecycle()
 			lifecycleErr = lifecycle.RunPostBuild(ctx)
@@ -52,6 +45,14 @@ func (p *Plan) Build(ctx context.Context, o BuildOptions) (err error) {
 				}
 				return
 			}
+		}
+		lifecycleErr = p.body.Lifecycle.RunPostBuild(ctx)
+		if lifecycleErr != nil {
+			log.Errorf("got an error from postbuild hooks: %v", lifecycleErr)
+			if err == nil {
+				err = lifecycleErr
+			}
+			return
 		}
 	}()
 

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -34,11 +34,23 @@ func (p *Plan) Build(ctx context.Context, o BuildOptions) (err error) {
 	}
 
 	defer func() {
-		lifecycleErr := p.body.Lifecycle.RunPostBuild(ctx)
-		if lifecycleErr != nil {
-			log.Errorf("got an error from postbuild hooks: %v", lifecycleErr)
+		lifeCycleErr := p.body.Lifecycle.RunPostBuild(ctx)
+		if lifeCycleErr != nil {
+			log.Errorf("got an error from postbuild hooks: %v", lifeCycleErr)
 			if err == nil {
-				err = lifecycleErr
+				err = lifeCycleErr
+			}
+			return
+		}
+		for _, r := range p.body.Releases {
+			lifeCycle := r.LifeCycle()
+			lifeCycleErr = lifeCycle.RunPostBuild(ctx)
+			if lifeCycleErr != nil {
+				log.Errorf("got an error from postbuild hooks for release %s: %v", r.Name(), lifeCycleErr)
+				if err == nil {
+					err = lifeCycleErr
+				}
+				return
 			}
 		}
 	}()

--- a/pkg/plan/build_releases.go
+++ b/pkg/plan/build_releases.go
@@ -34,8 +34,8 @@ func (p *Plan) buildReleases(ctx context.Context, o BuildOptions) ([]release.Con
 	// Run per-release build hook (in dependency order)
 	for _, r := range plan {
 		// Run hooks
-		lifeCycle := r.LifeCycle()
-		err := lifeCycle.RunPreBuild(ctx)
+		lifecycle := r.Lifecycle()
+		err := lifecycle.RunPreBuild(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/plan/build_releases_internal_test.go
+++ b/pkg/plan/build_releases_internal_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -129,7 +130,7 @@ func (ts *BuildReleasesTestSuite) TestNoReleases() {
 	p := New(filepath.Join(tmpDir, Dir))
 	p.NewBody()
 
-	releases, err := p.buildReleases(BuildOptions{})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{})
 
 	ts.Require().NoError(err)
 	ts.Empty(releases)
@@ -144,7 +145,7 @@ func (ts *BuildReleasesTestSuite) TestNoMatchingReleases() {
 
 	p.SetReleases(mockedRelease)
 
-	releases, err := p.buildReleases(BuildOptions{Tags: []string{"abc"}, MatchAll: true})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: []string{"abc"}, MatchAll: true})
 	ts.Require().NoError(err)
 	ts.Empty(releases)
 
@@ -170,7 +171,7 @@ func (ts *BuildReleasesTestSuite) TestDuplicateReleases() {
 
 	p.SetReleases(rel1, rel2)
 
-	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 
 	var e *release.DuplicateError
 	ts.Require().ErrorAs(err, &e)
@@ -196,7 +197,7 @@ func (ts *BuildReleasesTestSuite) TestMissingRequiredDependency() {
 
 	p.SetReleases(rel)
 
-	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 	ts.ErrorIs(err, release.ErrDepFailed)
 	ts.Empty(releases)
 
@@ -218,7 +219,7 @@ func (ts *BuildReleasesTestSuite) TestMissingOptionalDependency() {
 
 	p.SetReleases(rel)
 
-	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 	ts.Require().NoError(err)
 	ts.Len(releases, 1)
 	ts.Contains(releases, rel)
@@ -249,7 +250,7 @@ func (ts *BuildReleasesTestSuite) TestUnmatchedDependency() {
 
 	p.SetReleases(rel1, rel2)
 
-	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 	ts.Require().NoError(err)
 	ts.Len(releases, 2)
 	ts.Contains(releases, rel1)
@@ -276,7 +277,7 @@ func (ts *BuildReleasesTestSuite) TestDisabledDependencies() {
 
 	p.SetReleases(rel1, rel2)
 
-	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: false})
+	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: false})
 	ts.Require().NoError(err)
 	ts.Len(releases, 1)
 	ts.Contains(releases, rel1)

--- a/pkg/plan/mock_release_export_test.go
+++ b/pkg/plan/mock_release_export_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/helmwave/helmwave/pkg/hooks"
 	"github.com/helmwave/helmwave/pkg/monitor"
 	"github.com/helmwave/helmwave/pkg/release"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
@@ -208,4 +209,8 @@ func (r *MockReleaseConfig) Monitors() []release.MonitorReference {
 
 func (r *MockReleaseConfig) NotifyMonitorsFailed(context.Context, ...monitor.Config) {
 	r.Called()
+}
+
+func (r *MockReleaseConfig) LifeCycle() hooks.Lifecycle {
+	return r.Called().Get(0).(hooks.Lifecycle)
 }

--- a/pkg/plan/mock_release_export_test.go
+++ b/pkg/plan/mock_release_export_test.go
@@ -211,6 +211,6 @@ func (r *MockReleaseConfig) NotifyMonitorsFailed(context.Context, ...monitor.Con
 	r.Called()
 }
 
-func (r *MockReleaseConfig) LifeCycle() hooks.Lifecycle {
+func (r *MockReleaseConfig) Lifecycle() hooks.Lifecycle {
 	return r.Called().Get(0).(hooks.Lifecycle)
 }

--- a/pkg/release/config.go
+++ b/pkg/release/config.go
@@ -24,7 +24,7 @@ type config struct {
 	helm *helm.EnvSettings
 	log  *log.Entry
 
-	Lifecycle              hooks.Lifecycle `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty" jsonschema:"description=Lifecycle hooks"`
+	LifecycleF             hooks.Lifecycle `yaml:"lifecycle,omitempty" json:"lifecycle,omitempty" jsonschema:"description=Lifecycle hooks"`
 	Store                  map[string]any  `yaml:"store,omitempty" json:"store,omitempty" jsonschema:"title=The Store,description=It allows to pass your custom fields from helmwave.yml to values"`
 	ChartF                 Chart           `yaml:"chart,omitempty" json:"chart,omitempty" jsonschema:"title=Chart reference,description=Describes chart that release uses,oneof_type=string;object"`
 	Tests                  configTests     `yaml:"tests,omitempty" json:"tests,omitempty" jsonschema:"description=Configuration for helm tests"`
@@ -283,6 +283,6 @@ func (rel *config) Monitors() []MonitorReference {
 	return rel.MonitorsF
 }
 
-func (rel *config) LifeCycle() hooks.Lifecycle {
-	return rel.Lifecycle
+func (rel *config) Lifecycle() hooks.Lifecycle {
+	return rel.LifecycleF
 }

--- a/pkg/release/config.go
+++ b/pkg/release/config.go
@@ -282,3 +282,7 @@ func (rel *config) Monitors() []MonitorReference {
 
 	return rel.MonitorsF
 }
+
+func (rel *config) LifeCycle() hooks.Lifecycle {
+	return rel.Lifecycle
+}

--- a/pkg/release/interface.go
+++ b/pkg/release/interface.go
@@ -46,7 +46,7 @@ type Config interface {
 	Validate() error
 	Monitors() []MonitorReference
 	NotifyMonitorsFailed(ctx context.Context, monitors ...monitor.Config)
-	LifeCycle() hooks.Lifecycle
+	Lifecycle() hooks.Lifecycle
 }
 
 type HelmActionRunner interface {

--- a/pkg/release/interface.go
+++ b/pkg/release/interface.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/helmwave/helmwave/pkg/helper"
+	"github.com/helmwave/helmwave/pkg/hooks"
 	"github.com/helmwave/helmwave/pkg/log"
 	"github.com/helmwave/helmwave/pkg/monitor"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
@@ -45,6 +46,7 @@ type Config interface {
 	Validate() error
 	Monitors() []MonitorReference
 	NotifyMonitorsFailed(ctx context.Context, monitors ...monitor.Config)
+	LifeCycle() hooks.Lifecycle
 }
 
 type HelmActionRunner interface {

--- a/pkg/release/rollback.go
+++ b/pkg/release/rollback.go
@@ -11,13 +11,13 @@ func (rel *config) Rollback(ctx context.Context, version int) (err error) {
 	ctx = helper.ContextWithReleaseUniq(ctx, rel.Uniq())
 
 	// Run hooks
-	err = rel.Lifecycle.RunPreRollback(ctx)
+	err = rel.LifecycleF.RunPreRollback(ctx)
 	if err != nil {
 		return
 	}
 
 	defer func() {
-		lifecycleErr := rel.Lifecycle.RunPostRollback(ctx)
+		lifecycleErr := rel.LifecycleF.RunPostRollback(ctx)
 		if lifecycleErr != nil {
 			rel.Logger().Errorf("got an error from postrollback hooks: %v", lifecycleErr)
 			if err == nil {

--- a/pkg/release/sync.go
+++ b/pkg/release/sync.go
@@ -56,11 +56,11 @@ type lifecycleHook func(context.Context) error
 
 func (rel *config) syncLifecycleHooks() (pre, post lifecycleHook) {
 	if rel.dryRun {
-		pre = rel.Lifecycle.RunPreBuild
-		post = rel.Lifecycle.RunPostBuild
+		pre = rel.LifecycleF.RunPreBuild
+		post = rel.LifecycleF.RunPostBuild
 	} else {
-		pre = rel.Lifecycle.RunPreUp
-		post = rel.Lifecycle.RunPostUp
+		pre = rel.LifecycleF.RunPreUp
+		post = rel.LifecycleF.RunPostUp
 	}
 
 	return

--- a/pkg/release/uninstall.go
+++ b/pkg/release/uninstall.go
@@ -12,13 +12,13 @@ func (rel *config) Uninstall(ctx context.Context) (resp *release.UninstallReleas
 	ctx = helper.ContextWithReleaseUniq(ctx, rel.Uniq())
 
 	// Run hooks
-	err = rel.Lifecycle.RunPreDown(ctx)
+	err = rel.LifecycleF.RunPreDown(ctx)
 	if err != nil {
 		return
 	}
 
 	defer func() {
-		lifecycleErr := rel.Lifecycle.RunPostDown(ctx)
+		lifecycleErr := rel.LifecycleF.RunPostDown(ctx)
 		if lifecycleErr != nil {
 			if err == nil {
 				err = lifecycleErr


### PR DESCRIPTION
Closes #935 

Actually there are pre/post-up/down/rollback code for release-scope lifecycle hooks, only build hook is missing. 