### PR TITLE
FIX: typo in ENTRYPOINT, otherwise:  stat /bin/${PROJECT}}: no such f…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN go build -a -o "/${PROJECT}" "./cmd/${PROJECT}"
 ## Base image with shell
 FROM alpine:${ALPINE_VERSION} as base-release
 RUN apk --update --no-cache add ca-certificates && update-ca-certificates
-ENTRYPOINT ["/bin/${PROJECT}}"]
+ENTRYPOINT ["/bin/${PROJECT}"]
 
 
 ### Base image with shell and debugging tools


### PR DESCRIPTION
While attempting to use Helmwave from within docker via alias (`alias helmwave='docker run --rm -it -v $PWD:/tmp/cmd -w /tmp/cmd diamon/helmwave:latest'`):

```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: 
runc create failed: unable to start container process: error during container init: 
exec: "/bin/${PROJECT}}": stat /bin/${PROJECT}}: no such file or directory: unknown
```

At the same time overriding entrypoint helps:
```sh
docker run --rm -it  --entrypoint helmwave diamon/helmwave:latest ver
0.41.9
```