### PR TITLE
Bugfix/concurrent map writes for toDeleteMap

### DIFF
--- a/.changes/unreleased/Fixed-20250829-165219.yaml
+++ b/.changes/unreleased/Fixed-20250829-165219.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: fix concurrent map writes for toDeleteMap
+time: 2025-08-29T16:52:19.120568023+03:00
+custom:
+    Author: alexchspb
+    Issue: ""

--- a/pkg/release/values.go
+++ b/pkg/release/values.go
@@ -222,6 +222,7 @@ func (v *ValuesReference) fetch(ctx context.Context, l *log.Entry) error {
 }
 
 func (rel *config) BuildValues(ctx context.Context, dir, templater string) error {
+	var mu sync.Mutex
 	vals := rel.Values()
 
 	wg := parallel.NewWaitGroup()
@@ -248,7 +249,9 @@ func (rel *config) BuildValues(ctx context.Context, dir, templater string) error
 			switch {
 			case !v.Strict && errors.Is(ErrValuesNotExist, err):
 				l.WithError(err).Warn("skipping values...")
+				mu.Lock()
 				toDeleteMap[v] = true
+				mu.Unlock()
 			case err != nil:
 				l.WithError(err).Error("failed to build values")
 


### PR DESCRIPTION
Fix concurrent map writes for cases when multiple absent values-files provided in helmwave.yml