### PR TITLE
fix: remove duplicate per-release pre-build hook invocation

### DIFF
--- a/.changes/unreleased/Fixed-20251216-220407.yaml
+++ b/.changes/unreleased/Fixed-20251216-220407.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'fix: remove duplicate per-release pre-build hook invocation'
+time: 2025-12-16T22:04:07.793340426+08:00
+custom:
+    Author: Vigilans
+    Issue: ""

--- a/.changes/unreleased/Fixed-20260220-110658.yaml
+++ b/.changes/unreleased/Fixed-20260220-110658.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: 'fix: build release chart after `pre_build` hook'
+time: 2026-02-20T11:06:58.552961012+08:00
+custom:
+    Author: Vigilans
+    Issue: ""

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -48,7 +48,7 @@ func (p *Plan) Build(ctx context.Context, o BuildOptions) (err error) {
 }
 
 func (p *Plan) build(ctx context.Context, o BuildOptions) (err error) {
-	p.body.Releases, err = p.buildReleases(ctx, o)
+	p.body.Releases, err = p.buildReleases(o)
 	if err != nil {
 		return err
 	}

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -73,11 +73,6 @@ func (p *Plan) build(ctx context.Context, o BuildOptions) (err error) {
 		return err
 	}
 
-	err = p.buildCharts()
-	if err != nil {
-		return err
-	}
-
 	err = p.body.Validate()
 	if err != nil {
 		return err

--- a/pkg/plan/build_charts.go
+++ b/pkg/plan/build_charts.go
@@ -24,3 +24,7 @@ func (p *Plan) buildCharts() error {
 
 	return wg.Wait()
 }
+
+func (p *Plan) buildReleaseChart(rel release.Config) error {
+	return rel.DownloadChart(p.tmpDir)
+}

--- a/pkg/plan/build_manifests.go
+++ b/pkg/plan/build_manifests.go
@@ -87,6 +87,11 @@ func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu 
 		}
 	}()
 
+	err = p.buildReleaseChart(rel)
+	if err != nil {
+		return err
+	}
+
 	err = p.buildReleaseValues(ctx, rel, mu)
 	if err != nil {
 		return err

--- a/pkg/plan/build_releases.go
+++ b/pkg/plan/build_releases.go
@@ -1,7 +1,6 @@
 package plan
 
 import (
-	"context"
 	"slices"
 
 	"github.com/helmwave/helmwave/pkg/helper"
@@ -9,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (p *Plan) buildReleases(ctx context.Context, o BuildOptions) ([]release.Config, error) {
+func (p *Plan) buildReleases(o BuildOptions) ([]release.Config, error) {
 	log.Info("🔨 Building releases...")
 
 	plan := make([]release.Config, 0)
@@ -29,16 +28,6 @@ func (p *Plan) buildReleases(ctx context.Context, o BuildOptions) ([]release.Con
 		if err != nil {
 			log.WithError(err).Error("failed to build releases plan")
 
-			return nil, err
-		}
-	}
-
-	// Run per-release build hook (in dependency order)
-	for _, r := range plan {
-		// Run hooks
-		lifecycle := r.Lifecycle()
-		err := lifecycle.RunPreBuild(ctx)
-		if err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/plan/build_releases_internal_test.go
+++ b/pkg/plan/build_releases_internal_test.go
@@ -1,11 +1,9 @@
 package plan
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
-	"github.com/helmwave/helmwave/pkg/hooks"
 	"github.com/helmwave/helmwave/pkg/release"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
 	"github.com/stretchr/testify/suite"
@@ -131,7 +129,7 @@ func (ts *BuildReleasesTestSuite) TestNoReleases() {
 	p := New(filepath.Join(tmpDir, Dir))
 	p.NewBody()
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{})
+	releases, err := p.buildReleases(BuildOptions{})
 
 	ts.Require().NoError(err)
 	ts.Empty(releases)
@@ -146,7 +144,7 @@ func (ts *BuildReleasesTestSuite) TestNoMatchingReleases() {
 
 	p.SetReleases(mockedRelease)
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: []string{"abc"}, MatchAll: true})
+	releases, err := p.buildReleases(BuildOptions{Tags: []string{"abc"}, MatchAll: true})
 	ts.Require().NoError(err)
 	ts.Empty(releases)
 
@@ -172,7 +170,7 @@ func (ts *BuildReleasesTestSuite) TestDuplicateReleases() {
 
 	p.SetReleases(rel1, rel2)
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 
 	var e *release.DuplicateError
 	ts.Require().ErrorAs(err, &e)
@@ -198,7 +196,7 @@ func (ts *BuildReleasesTestSuite) TestMissingRequiredDependency() {
 
 	p.SetReleases(rel)
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 	ts.ErrorIs(err, release.ErrDepFailed)
 	ts.Empty(releases)
 
@@ -217,11 +215,10 @@ func (ts *BuildReleasesTestSuite) TestMissingOptionalDependency() {
 	rel.On("Uniq").Return(u)
 	rel.On("DependsOn").Return([]*release.DependsOnReference{{Name: "blabla", Optional: true}})
 	rel.On("SetDependsOn", []*release.DependsOnReference{}).Return()
-	rel.On("Lifecycle").Return(hooks.Lifecycle{})
 
 	p.SetReleases(rel)
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 	ts.Require().NoError(err)
 	ts.Len(releases, 1)
 	ts.Contains(releases, rel)
@@ -243,18 +240,16 @@ func (ts *BuildReleasesTestSuite) TestUnmatchedDependency() {
 	rel1.On("Uniq").Return(u1)
 	rel1.On("DependsOn").Return(deps)
 	rel1.On("SetDependsOn", deps).Return()
-	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
 
 	rel2 := NewMockReleaseConfig(ts.T())
 	rel2.On("Tags").Return([]string{})
 	rel2.On("Uniq").Return(u2)
 	rel2.On("DependsOn").Return([]*release.DependsOnReference{})
 	rel2.On("SetDependsOn", []*release.DependsOnReference{}).Return()
-	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
 
 	p.SetReleases(rel1, rel2)
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
+	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: true})
 	ts.Require().NoError(err)
 	ts.Len(releases, 2)
 	ts.Contains(releases, rel1)
@@ -275,14 +270,13 @@ func (ts *BuildReleasesTestSuite) TestDisabledDependencies() {
 	rel1.On("Tags").Return(tags)
 	rel1.On("Uniq").Return(u1)
 	rel1.On("SetDependsOn", []*release.DependsOnReference{}).Return()
-	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
 
 	rel2 := NewMockReleaseConfig(ts.T())
 	rel2.On("Tags").Return([]string{})
 
 	p.SetReleases(rel1, rel2)
 
-	releases, err := p.buildReleases(context.Background(), BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: false})
+	releases, err := p.buildReleases(BuildOptions{Tags: tags, MatchAll: true, EnableDependencies: false})
 	ts.Require().NoError(err)
 	ts.Len(releases, 1)
 	ts.Contains(releases, rel1)


### PR DESCRIPTION
Per-release pre-build hook is executed twice. This PR removes the redundant one in `build_releases`.

Another call happens in `SyncDryRun(ctx, true)` in `buildManifest`:

https://github.com/helmwave/helmwave/blob/3512e642ee5c0320e9ae76aa94e2162486093454/pkg/plan/build_manifests.go#L40-L45

---

Update: lifecycle code in `SyncDryRun` -> `Sync`:

https://github.com/helmwave/helmwave/blob/031e32f1d78133767f0614113394cf9adaecdc1e/pkg/release/sync.go#L10-L28

We can see that per-release pre and post hook are called here. The removed code in this PR only does per-release pre-build hook but not post-build.