### PR TITLE
feat: build manifests and values in release dependency order

### DIFF
--- a/.changes/unreleased/New feature-20251225-205603.yaml
+++ b/.changes/unreleased/New feature-20251225-205603.yaml
@@ -1,0 +1,6 @@
+kind: New feature
+body: 'feat: build manifests and values in release dependency order'
+time: 2025-12-25T20:56:03.287219431+08:00
+custom:
+    Author: Vigilans
+    Issue: ""

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -53,11 +53,6 @@ func (p *Plan) build(ctx context.Context, o BuildOptions) (err error) {
 		return err
 	}
 
-	err = p.buildValues(ctx)
-	if err != nil {
-		return err
-	}
-
 	p.body.Repositories, err = p.buildRepositories()
 	if err != nil {
 		return err
@@ -85,6 +80,10 @@ func (p *Plan) build(ctx context.Context, o BuildOptions) (err error) {
 
 	err = p.body.Validate()
 	if err != nil {
+		return err
+	}
+
+	if err := p.ValidateValuesBuild(); err != nil {
 		return err
 	}
 

--- a/pkg/plan/build_manifests.go
+++ b/pkg/plan/build_manifests.go
@@ -6,39 +6,93 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
-
+	"github.com/helmwave/helmwave/pkg/parallel"
 	"github.com/helmwave/helmwave/pkg/release"
+	"github.com/helmwave/helmwave/pkg/release/dependency"
 	log "github.com/sirupsen/logrus"
 )
 
 func (p *Plan) buildManifest(ctx context.Context) error {
 	log.Info("🔨 Building manifests...")
 
-	wg, ctx := errgroup.WithContext(ctx)
-	wg.SetLimit(p.ParallelLimiter(ctx))
+	parallelLimit := p.ParallelLimiter(ctx)
 
-	mu := &sync.Mutex{}
+	releasesNodesChan := p.Graph().Run()
 
-	for _, rel := range p.body.Releases {
-		wg.Go(
-			func() error {
-				return p.buildReleaseManifest(ctx, rel, mu)
-			})
+	releasesWG := parallel.NewWaitGroup()
+	releasesWG.Add(parallelLimit)
+
+	releasesFails := make(map[release.Config]error)
+
+	releasesMutex := &sync.Mutex{}
+
+	for range parallelLimit {
+		go p.buildReleaseManifestWorker(ctx, releasesWG, releasesNodesChan, releasesMutex, releasesFails)
 	}
 
-	//nolint:wrapcheck
-	return wg.Wait()
+	if err := releasesWG.WaitWithContext(ctx); err != nil {
+		return err
+	}
+
+	return p.ApplyReport(releasesFails, nil)
 }
 
-func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu *sync.Mutex) error {
+//nolint:dupl
+func (p *Plan) buildReleaseManifestWorker(
+	ctx context.Context,
+	wg *parallel.WaitGroup,
+	nodesChan <-chan *dependency.Node[release.Config],
+	mu *sync.Mutex,
+	fails map[release.Config]error,
+) {
+	for node := range nodesChan {
+		rel := node.Data
+		err := p.buildReleaseManifest(ctx, rel, mu)
+		if err != nil {
+			if rel.AllowFailure() {
+				rel.Logger().Errorf("release is allowed to fail, marked as succeeded to dependencies")
+				node.SetSucceeded()
+			} else {
+				node.SetFailed()
+			}
+
+			mu.Lock()
+			fails[rel] = err
+			mu.Unlock()
+
+			wg.ErrChan() <- err
+		} else {
+			node.SetSucceeded()
+		}
+	}
+	wg.Done()
+}
+
+func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu *sync.Mutex) (err error) {
 	l := rel.Logger()
 
 	if err := rel.ChartDepsUpd(); err != nil {
 		l.WithError(err).Warn("❌ can't get dependencies")
 	}
 
-	r, err := rel.SyncDryRun(ctx, true)
+	lifecycle := rel.Lifecycle()
+	err = lifecycle.RunPreBuild(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		lifecycleErr := lifecycle.RunPostBuild(ctx)
+		if lifecycleErr != nil && err == nil {
+			err = lifecycleErr
+		}
+	}()
+
+	err = p.buildReleaseValues(ctx, rel)
+	if err != nil {
+		return err
+	}
+
+	r, err := rel.SyncDryRun(ctx, false)
 	if err != nil || r == nil {
 		l.Errorf("❌ can't get manifests: %v", err)
 

--- a/pkg/plan/build_manifests_internal_test.go
+++ b/pkg/plan/build_manifests_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/helmwave/helmwave/pkg/hooks"
+	"github.com/helmwave/helmwave/pkg/release"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
 	"github.com/helmwave/helmwave/tests"
 	"github.com/stretchr/testify/suite"
@@ -46,6 +48,10 @@ func (ts *BuildManifestsTestSuite) TestMultipleReleases() {
 	rel1.On("Sync").Return(&helmRelease.Release{}, nil)
 	rel1.On("HooksDisabled").Return(false)
 	rel1.On("Uniq").Return(u1)
+	rel1.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel1.On("BuildValues").Return(nil)
+	rel1.On("Values").Return([]release.ValuesReference{})
 
 	rel2 := NewMockReleaseConfig(ts.T())
 	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
@@ -54,6 +60,10 @@ func (ts *BuildManifestsTestSuite) TestMultipleReleases() {
 	rel2.On("Sync").Return(&helmRelease.Release{}, nil)
 	rel2.On("HooksDisabled").Return(false)
 	rel2.On("Uniq").Return(u2)
+	rel2.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel2.On("BuildValues").Return(nil)
+	rel2.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel1, rel2)
 
@@ -81,6 +91,10 @@ func (ts *BuildManifestsTestSuite) TestChartDepsUpdError() {
 	rel.On("Sync").Return(&helmRelease.Release{}, nil)
 	rel.On("HooksDisabled").Return(false)
 	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel)
 
@@ -98,10 +112,17 @@ func (ts *BuildManifestsTestSuite) TestSyncError() {
 	p := New(".")
 
 	rel := NewMockReleaseConfig(ts.T())
+	uniq, _ := uniqname.NewFromString("redis1@defaultblabla")
 	errExpected := errors.New(ts.T().Name())
 	rel.On("ChartDepsUpd").Return(nil)
 	rel.On("DryRun").Return()
 	rel.On("Sync").Return(&helmRelease.Release{}, errExpected)
+	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("AllowFailure").Return(false)
 
 	p.SetReleases(rel)
 
@@ -125,6 +146,10 @@ func (ts *BuildManifestsTestSuite) TestDisabledHooks() {
 	}, nil)
 	rel.On("HooksDisabled").Return(true)
 	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel)
 
@@ -156,6 +181,10 @@ func (ts *BuildManifestsTestSuite) TestEnabledHooks() {
 	}, nil)
 	rel.On("HooksDisabled").Return(false)
 	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel)
 

--- a/pkg/plan/build_manifests_internal_test.go
+++ b/pkg/plan/build_manifests_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/helmwave/helmwave/pkg/release"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
 	"github.com/helmwave/helmwave/tests"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	helmRelease "helm.sh/helm/v3/pkg/release"
 )
@@ -196,4 +197,99 @@ func (ts *BuildManifestsTestSuite) TestEnabledHooks() {
 	ts.Require().Equal(p.manifests[uniq], fmt.Sprintf("%[1]s---\n# Source: %[1]s\n%[1]s\n", ts.T().Name()))
 
 	rel.AssertExpectations(ts.T())
+}
+
+func (ts *BuildManifestsTestSuite) TestReleasesWithDependency() {
+	p := New(".")
+
+	// Track build order to verify dependency order is respected
+	var buildOrder []string
+
+	// rel1 is a dependency of rel2
+	rel1 := NewMockReleaseConfig(ts.T())
+	u1, _ := uniqname.NewFromString("redis1@defaultblabla")
+	rel1.On("ChartDepsUpd").Return(nil)
+	rel1.On("DryRun").Return()
+	rel1.On("Sync").Run(func(args mock.Arguments) {
+		buildOrder = append(buildOrder, "rel1")
+	}).Return(&helmRelease.Release{Manifest: "rel1-manifest"}, nil)
+	rel1.On("HooksDisabled").Return(false)
+	rel1.On("Uniq").Return(u1)
+	rel1.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel1.On("BuildValues").Return(nil)
+	rel1.On("Values").Return([]release.ValuesReference{})
+
+	// rel2 depends on rel1
+	rel2 := NewMockReleaseConfig(ts.T())
+	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
+	rel2.On("ChartDepsUpd").Return(nil)
+	rel2.On("DryRun").Return()
+	rel2.On("Sync").Run(func(args mock.Arguments) {
+		buildOrder = append(buildOrder, "rel2")
+	}).Return(&helmRelease.Release{Manifest: "rel2-manifest"}, nil)
+	rel2.On("HooksDisabled").Return(false)
+	rel2.On("Uniq").Return(u2)
+	rel2.On("DependsOn").Return([]*release.DependsOnReference{
+		{Name: u1.String()},
+	})
+	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel2.On("BuildValues").Return(nil)
+	rel2.On("Values").Return([]release.ValuesReference{})
+
+	// Pass in reverse order to verify dependency graph corrects the order
+	p.SetReleases(rel2, rel1)
+
+	err := p.buildManifest(ts.ctx)
+
+	ts.Require().NoError(err)
+	ts.Require().Len(p.manifests, 2)
+	ts.Require().Contains(p.manifests, u1)
+	ts.Require().Contains(p.manifests, u2)
+	ts.Require().Equal("rel1-manifest", p.manifests[u1])
+	ts.Require().Equal("rel2-manifest", p.manifests[u2])
+
+	// Verify build order: rel1 (dependency) must be built before rel2, regardless of input order
+	ts.Require().Equal([]string{"rel1", "rel2"}, buildOrder, "dependency should be built before dependent")
+
+	rel1.AssertExpectations(ts.T())
+	rel2.AssertExpectations(ts.T())
+}
+
+func (ts *BuildManifestsTestSuite) TestReleasesWithDependencyFailure() {
+	p := New(".")
+
+	// rel1 is a dependency of rel2, but rel1 will fail
+	rel1 := NewMockReleaseConfig(ts.T())
+	u1, _ := uniqname.NewFromString("redis1@defaultblabla")
+	errExpected := errors.New(ts.T().Name())
+	rel1.On("ChartDepsUpd").Return(nil)
+	rel1.On("DryRun").Return()
+	rel1.On("Sync").Return(&helmRelease.Release{}, errExpected)
+	rel1.On("Uniq").Return(u1)
+	rel1.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel1.On("BuildValues").Return(nil)
+	rel1.On("Values").Return([]release.ValuesReference{})
+	rel1.On("AllowFailure").Return(false)
+
+	// rel2 depends on rel1, should NOT be built because rel1 fails
+	rel2 := NewMockReleaseConfig(ts.T())
+	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
+	rel2.On("Uniq").Return(u2)
+	rel2.On("DependsOn").Return([]*release.DependsOnReference{
+		{Name: u1.String()},
+	})
+
+	p.SetReleases(rel1, rel2)
+
+	err := p.buildManifest(ts.ctx)
+
+	ts.Require().ErrorIs(err, errExpected)
+	ts.Require().NotContains(p.manifests, u1)
+	ts.Require().NotContains(p.manifests, u2)
+
+	rel1.AssertExpectations(ts.T())
+	rel2.AssertNotCalled(ts.T(), "ChartDepsUpd")
+	rel2.AssertNotCalled(ts.T(), "Sync")
 }

--- a/pkg/plan/build_values.go
+++ b/pkg/plan/build_values.go
@@ -2,11 +2,13 @@ package plan
 
 import (
 	"context"
+	"sync"
 
 	"github.com/helmwave/helmwave/pkg/helper"
+	"github.com/helmwave/helmwave/pkg/parallel"
 	"github.com/helmwave/helmwave/pkg/release"
+	"github.com/helmwave/helmwave/pkg/release/dependency"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 func (p *Plan) buildValues(ctx context.Context) error {
@@ -15,20 +17,62 @@ func (p *Plan) buildValues(ctx context.Context) error {
 		return err
 	}
 
-	limit := p.ParallelLimiter(ctx)
-	wg, ctx := errgroup.WithContext(ctx)
-	wg.SetLimit(limit)
+	parallelLimit := p.ParallelLimiter(ctx)
 
-	for _, rel := range p.body.Releases {
-		wg.Go(func() error {
-			return p.buildReleaseValues(ctx, rel)
-		})
+	releasesNodesChan := p.Graph().Run()
+
+	releasesWG := parallel.NewWaitGroup()
+	releasesWG.Add(parallelLimit)
+
+	releasesFails := make(map[release.Config]error)
+
+	releasesMutex := &sync.Mutex{}
+
+	for range parallelLimit {
+		go p.buildReleaseValuesWorker(ctx, releasesWG, releasesNodesChan, releasesMutex, releasesFails)
 	}
-	//nolint:wrapcheck
-	return wg.Wait()
+
+	if err := releasesWG.WaitWithContext(ctx); err != nil {
+		return err
+	}
+
+	return p.ApplyReport(releasesFails, nil)
+}
+
+//nolint:dupl
+func (p *Plan) buildReleaseValuesWorker(
+	ctx context.Context,
+	wg *parallel.WaitGroup,
+	nodesChan <-chan *dependency.Node[release.Config],
+	mu *sync.Mutex,
+	fails map[release.Config]error,
+) {
+	for node := range nodesChan {
+		rel := node.Data
+		err := p.buildReleaseValues(ctx, rel)
+		if err != nil {
+			if rel.AllowFailure() {
+				rel.Logger().Errorf("release is allowed to fail, marked as succeeded to dependencies")
+				node.SetSucceeded()
+			} else {
+				node.SetFailed()
+			}
+
+			mu.Lock()
+			fails[rel] = err
+			mu.Unlock()
+
+			wg.ErrChan() <- err
+		} else {
+			node.SetSucceeded()
+		}
+	}
+	wg.Done()
 }
 
 func (p *Plan) buildReleaseValues(ctx context.Context, rel release.Config) error {
+	log.Info("🔨 Building release values...")
+
 	err := rel.BuildValues(ctx, p.tmpDir, p.templater)
 	if err != nil {
 		log.Errorf("❌ %s values: %v", rel.Uniq(), err)

--- a/pkg/plan/build_values_internal_test.go
+++ b/pkg/plan/build_values_internal_test.go
@@ -61,6 +61,8 @@ func (ts *BuildValuesTestSuite) TestValuesBuildError() {
 	mockedRelease.On("Values").Return([]release.ValuesReference{
 		{Src: tmpValues},
 	})
+	mockedRelease.On("DependsOn").Return([]*release.DependsOnReference{})
+	mockedRelease.On("AllowFailure").Return(false)
 
 	errBuildValues := errors.New("values build error")
 	mockedRelease.On("BuildValues").Return(errBuildValues)
@@ -91,6 +93,7 @@ func (ts *BuildValuesTestSuite) TestSuccess() {
 	})
 	mockedRelease.On("BuildValues").Return(nil)
 	mockedRelease.On("Uniq").Return()
+	mockedRelease.On("DependsOn").Return([]*release.DependsOnReference{})
 
 	p.body = &planBody{
 		Releases: release.Configs{mockedRelease},

--- a/pkg/plan/export_internal_test.go
+++ b/pkg/plan/export_internal_test.go
@@ -57,6 +57,7 @@ func (ts *ExportTestSuite) TestValuesOneRelease() {
 	mockedRelease.On("BuildValues").Return(nil)
 	mockedRelease.On("KubeContext").Return("")
 	mockedRelease.On("Uniq").Return()
+	mockedRelease.On("DependsOn").Return([]*release.DependsOnReference{})
 
 	p.body = &planBody{
 		Releases: release.Configs{mockedRelease},


### PR DESCRIPTION
### Description

Build release manifests using dependency graph instead of totally parallel. Each release's values are now built immediately before its manifests, ensuring that values rendering in dependent releases can access their dependencies' build artifacts.

### Motivation

This change lays the groundwork for upcoming template functions:
- `getPlan` / `getManifests`: Allow values to fetch built manifests of depending releases
- Enhanced `getValues`: Support fetching rendered values of depending releases

### Changes

- Manifests are now built following the release dependency graph
- Values building is integrated into the manifest build phase (per-release, just before manifest generation)
- Added tests to verify dependency order is respected