### PR TITLE
feat: add `getPlan` and `getManifests` template functions

### DIFF
--- a/.changes/unreleased/New feature-20251225-205603.yaml
+++ b/.changes/unreleased/New feature-20251225-205603.yaml
@@ -1,0 +1,6 @@
+kind: New feature
+body: 'feat: build manifests and values in release dependency order'
+time: 2025-12-25T20:56:03.287219431+08:00
+custom:
+    Author: Vigilans
+    Issue: ""

--- a/.changes/unreleased/New feature-20251225-210137.yaml
+++ b/.changes/unreleased/New feature-20251225-210137.yaml
@@ -1,0 +1,6 @@
+kind: New feature
+body: 'feat: add `getPlan` and `getManifests` template functions'
+time: 2025-12-25T21:01:37.066270238+08:00
+custom:
+    Author: Vigilans
+    Issue: ""

--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -53,11 +53,6 @@ func (p *Plan) build(ctx context.Context, o BuildOptions) (err error) {
 		return err
 	}
 
-	err = p.buildValues(ctx)
-	if err != nil {
-		return err
-	}
-
 	p.body.Repositories, err = p.buildRepositories()
 	if err != nil {
 		return err
@@ -85,6 +80,10 @@ func (p *Plan) build(ctx context.Context, o BuildOptions) (err error) {
 
 	err = p.body.Validate()
 	if err != nil {
+		return err
+	}
+
+	if err := p.ValidateValuesBuild(); err != nil {
 		return err
 	}
 

--- a/pkg/plan/build_manifests.go
+++ b/pkg/plan/build_manifests.go
@@ -87,7 +87,7 @@ func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu 
 		}
 	}()
 
-	err = p.buildReleaseValues(ctx, rel)
+	err = p.buildReleaseValues(ctx, rel, mu)
 	if err != nil {
 		return err
 	}

--- a/pkg/plan/build_manifests.go
+++ b/pkg/plan/build_manifests.go
@@ -6,39 +6,93 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
-
+	"github.com/helmwave/helmwave/pkg/parallel"
 	"github.com/helmwave/helmwave/pkg/release"
+	"github.com/helmwave/helmwave/pkg/release/dependency"
 	log "github.com/sirupsen/logrus"
 )
 
 func (p *Plan) buildManifest(ctx context.Context) error {
 	log.Info("🔨 Building manifests...")
 
-	wg, ctx := errgroup.WithContext(ctx)
-	wg.SetLimit(p.ParallelLimiter(ctx))
+	parallelLimit := p.ParallelLimiter(ctx)
 
-	mu := &sync.Mutex{}
+	releasesNodesChan := p.Graph().Run()
 
-	for _, rel := range p.body.Releases {
-		wg.Go(
-			func() error {
-				return p.buildReleaseManifest(ctx, rel, mu)
-			})
+	releasesWG := parallel.NewWaitGroup()
+	releasesWG.Add(parallelLimit)
+
+	releasesFails := make(map[release.Config]error)
+
+	releasesMutex := &sync.Mutex{}
+
+	for range parallelLimit {
+		go p.buildReleaseManifestWorker(ctx, releasesWG, releasesNodesChan, releasesMutex, releasesFails)
 	}
 
-	//nolint:wrapcheck
-	return wg.Wait()
+	if err := releasesWG.WaitWithContext(ctx); err != nil {
+		return err
+	}
+
+	return p.ApplyReport(releasesFails, nil)
 }
 
-func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu *sync.Mutex) error {
+//nolint:dupl
+func (p *Plan) buildReleaseManifestWorker(
+	ctx context.Context,
+	wg *parallel.WaitGroup,
+	nodesChan <-chan *dependency.Node[release.Config],
+	mu *sync.Mutex,
+	fails map[release.Config]error,
+) {
+	for node := range nodesChan {
+		rel := node.Data
+		err := p.buildReleaseManifest(ctx, rel, mu)
+		if err != nil {
+			if rel.AllowFailure() {
+				rel.Logger().Errorf("release is allowed to fail, marked as succeeded to dependencies")
+				node.SetSucceeded()
+			} else {
+				node.SetFailed()
+			}
+
+			mu.Lock()
+			fails[rel] = err
+			mu.Unlock()
+
+			wg.ErrChan() <- err
+		} else {
+			node.SetSucceeded()
+		}
+	}
+	wg.Done()
+}
+
+func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu *sync.Mutex) (err error) {
 	l := rel.Logger()
 
 	if err := rel.ChartDepsUpd(); err != nil {
 		l.WithError(err).Warn("❌ can't get dependencies")
 	}
 
-	r, err := rel.SyncDryRun(ctx, true)
+	lifecycle := rel.Lifecycle()
+	err = lifecycle.RunPreBuild(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		lifecycleErr := lifecycle.RunPostBuild(ctx)
+		if lifecycleErr != nil && err == nil {
+			err = lifecycleErr
+		}
+	}()
+
+	err = p.buildReleaseValues(ctx, rel)
+	if err != nil {
+		return err
+	}
+
+	r, err := rel.SyncDryRun(ctx, false)
 	if err != nil || r == nil {
 		l.Errorf("❌ can't get manifests: %v", err)
 

--- a/pkg/plan/build_manifests_internal_test.go
+++ b/pkg/plan/build_manifests_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/helmwave/helmwave/pkg/hooks"
+	"github.com/helmwave/helmwave/pkg/release"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
 	"github.com/helmwave/helmwave/tests"
 	"github.com/stretchr/testify/suite"
@@ -46,6 +48,10 @@ func (ts *BuildManifestsTestSuite) TestMultipleReleases() {
 	rel1.On("Sync").Return(&helmRelease.Release{}, nil)
 	rel1.On("HooksDisabled").Return(false)
 	rel1.On("Uniq").Return(u1)
+	rel1.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel1.On("BuildValues").Return(nil)
+	rel1.On("Values").Return([]release.ValuesReference{})
 
 	rel2 := NewMockReleaseConfig(ts.T())
 	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
@@ -54,6 +60,10 @@ func (ts *BuildManifestsTestSuite) TestMultipleReleases() {
 	rel2.On("Sync").Return(&helmRelease.Release{}, nil)
 	rel2.On("HooksDisabled").Return(false)
 	rel2.On("Uniq").Return(u2)
+	rel2.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel2.On("BuildValues").Return(nil)
+	rel2.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel1, rel2)
 
@@ -81,6 +91,10 @@ func (ts *BuildManifestsTestSuite) TestChartDepsUpdError() {
 	rel.On("Sync").Return(&helmRelease.Release{}, nil)
 	rel.On("HooksDisabled").Return(false)
 	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel)
 
@@ -98,10 +112,17 @@ func (ts *BuildManifestsTestSuite) TestSyncError() {
 	p := New(".")
 
 	rel := NewMockReleaseConfig(ts.T())
+	uniq, _ := uniqname.NewFromString("redis1@defaultblabla")
 	errExpected := errors.New(ts.T().Name())
 	rel.On("ChartDepsUpd").Return(nil)
 	rel.On("DryRun").Return()
 	rel.On("Sync").Return(&helmRelease.Release{}, errExpected)
+	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("AllowFailure").Return(false)
 
 	p.SetReleases(rel)
 
@@ -125,6 +146,10 @@ func (ts *BuildManifestsTestSuite) TestDisabledHooks() {
 	}, nil)
 	rel.On("HooksDisabled").Return(true)
 	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel)
 
@@ -156,6 +181,10 @@ func (ts *BuildManifestsTestSuite) TestEnabledHooks() {
 	}, nil)
 	rel.On("HooksDisabled").Return(false)
 	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(nil)
+	rel.On("Values").Return([]release.ValuesReference{})
 
 	p.SetReleases(rel)
 

--- a/pkg/plan/build_manifests_internal_test.go
+++ b/pkg/plan/build_manifests_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/helmwave/helmwave/pkg/release"
 	"github.com/helmwave/helmwave/pkg/release/uniqname"
 	"github.com/helmwave/helmwave/tests"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	helmRelease "helm.sh/helm/v3/pkg/release"
 )
@@ -196,4 +197,99 @@ func (ts *BuildManifestsTestSuite) TestEnabledHooks() {
 	ts.Require().Equal(p.manifests[uniq], fmt.Sprintf("%[1]s---\n# Source: %[1]s\n%[1]s\n", ts.T().Name()))
 
 	rel.AssertExpectations(ts.T())
+}
+
+func (ts *BuildManifestsTestSuite) TestReleasesWithDependency() {
+	p := New(".")
+
+	// Track build order to verify dependency order is respected
+	var buildOrder []string
+
+	// rel1 is a dependency of rel2
+	rel1 := NewMockReleaseConfig(ts.T())
+	u1, _ := uniqname.NewFromString("redis1@defaultblabla")
+	rel1.On("ChartDepsUpd").Return(nil)
+	rel1.On("DryRun").Return()
+	rel1.On("Sync").Run(func(args mock.Arguments) {
+		buildOrder = append(buildOrder, "rel1")
+	}).Return(&helmRelease.Release{Manifest: "rel1-manifest"}, nil)
+	rel1.On("HooksDisabled").Return(false)
+	rel1.On("Uniq").Return(u1)
+	rel1.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel1.On("BuildValues").Return(nil)
+	rel1.On("Values").Return([]release.ValuesReference{})
+
+	// rel2 depends on rel1
+	rel2 := NewMockReleaseConfig(ts.T())
+	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
+	rel2.On("ChartDepsUpd").Return(nil)
+	rel2.On("DryRun").Return()
+	rel2.On("Sync").Run(func(args mock.Arguments) {
+		buildOrder = append(buildOrder, "rel2")
+	}).Return(&helmRelease.Release{Manifest: "rel2-manifest"}, nil)
+	rel2.On("HooksDisabled").Return(false)
+	rel2.On("Uniq").Return(u2)
+	rel2.On("DependsOn").Return([]*release.DependsOnReference{
+		{Name: u1.String()},
+	})
+	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel2.On("BuildValues").Return(nil)
+	rel2.On("Values").Return([]release.ValuesReference{})
+
+	// Pass in reverse order to verify dependency graph corrects the order
+	p.SetReleases(rel2, rel1)
+
+	err := p.buildManifest(ts.ctx)
+
+	ts.Require().NoError(err)
+	ts.Require().Len(p.manifests, 2)
+	ts.Require().Contains(p.manifests, u1)
+	ts.Require().Contains(p.manifests, u2)
+	ts.Require().Equal("rel1-manifest", p.manifests[u1])
+	ts.Require().Equal("rel2-manifest", p.manifests[u2])
+
+	// Verify build order: rel1 (dependency) must be built before rel2, regardless of input order
+	ts.Require().Equal([]string{"rel1", "rel2"}, buildOrder, "dependency should be built before dependent")
+
+	rel1.AssertExpectations(ts.T())
+	rel2.AssertExpectations(ts.T())
+}
+
+func (ts *BuildManifestsTestSuite) TestReleasesWithDependencyFailure() {
+	p := New(".")
+
+	// rel1 is a dependency of rel2, but rel1 will fail
+	rel1 := NewMockReleaseConfig(ts.T())
+	u1, _ := uniqname.NewFromString("redis1@defaultblabla")
+	errExpected := errors.New(ts.T().Name())
+	rel1.On("ChartDepsUpd").Return(nil)
+	rel1.On("DryRun").Return()
+	rel1.On("Sync").Return(&helmRelease.Release{}, errExpected)
+	rel1.On("Uniq").Return(u1)
+	rel1.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel1.On("BuildValues").Return(nil)
+	rel1.On("Values").Return([]release.ValuesReference{})
+	rel1.On("AllowFailure").Return(false)
+
+	// rel2 depends on rel1, should NOT be built because rel1 fails
+	rel2 := NewMockReleaseConfig(ts.T())
+	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
+	rel2.On("Uniq").Return(u2)
+	rel2.On("DependsOn").Return([]*release.DependsOnReference{
+		{Name: u1.String()},
+	})
+
+	p.SetReleases(rel1, rel2)
+
+	err := p.buildManifest(ts.ctx)
+
+	ts.Require().ErrorIs(err, errExpected)
+	ts.Require().NotContains(p.manifests, u1)
+	ts.Require().NotContains(p.manifests, u2)
+
+	rel1.AssertExpectations(ts.T())
+	rel2.AssertNotCalled(ts.T(), "ChartDepsUpd")
+	rel2.AssertNotCalled(ts.T(), "Sync")
 }

--- a/pkg/plan/build_values.go
+++ b/pkg/plan/build_values.go
@@ -49,7 +49,7 @@ func (p *Plan) buildReleaseValuesWorker(
 ) {
 	for node := range nodesChan {
 		rel := node.Data
-		err := p.buildReleaseValues(ctx, rel)
+		err := p.buildReleaseValues(ctx, rel, mu)
 		if err != nil {
 			if rel.AllowFailure() {
 				rel.Logger().Errorf("release is allowed to fail, marked as succeeded to dependencies")
@@ -70,10 +70,12 @@ func (p *Plan) buildReleaseValuesWorker(
 	wg.Done()
 }
 
-func (p *Plan) buildReleaseValues(ctx context.Context, rel release.Config) error {
+func (p *Plan) buildReleaseValues(ctx context.Context, rel release.Config, mu *sync.Mutex) error {
 	log.Info("🔨 Building release values...")
 
-	err := rel.BuildValues(ctx, p.tmpDir, p.templater)
+	templateFuncs := p.templateFuncs(mu)
+
+	err := rel.BuildValues(ctx, p.tmpDir, p.templater, templateFuncs)
 	if err != nil {
 		log.Errorf("❌ %s values: %v", rel.Uniq(), err)
 

--- a/pkg/plan/build_values.go
+++ b/pkg/plan/build_values.go
@@ -2,11 +2,13 @@ package plan
 
 import (
 	"context"
+	"sync"
 
 	"github.com/helmwave/helmwave/pkg/helper"
+	"github.com/helmwave/helmwave/pkg/parallel"
 	"github.com/helmwave/helmwave/pkg/release"
+	"github.com/helmwave/helmwave/pkg/release/dependency"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 func (p *Plan) buildValues(ctx context.Context) error {
@@ -15,20 +17,62 @@ func (p *Plan) buildValues(ctx context.Context) error {
 		return err
 	}
 
-	limit := p.ParallelLimiter(ctx)
-	wg, ctx := errgroup.WithContext(ctx)
-	wg.SetLimit(limit)
+	parallelLimit := p.ParallelLimiter(ctx)
 
-	for _, rel := range p.body.Releases {
-		wg.Go(func() error {
-			return p.buildReleaseValues(ctx, rel)
-		})
+	releasesNodesChan := p.Graph().Run()
+
+	releasesWG := parallel.NewWaitGroup()
+	releasesWG.Add(parallelLimit)
+
+	releasesFails := make(map[release.Config]error)
+
+	releasesMutex := &sync.Mutex{}
+
+	for range parallelLimit {
+		go p.buildReleaseValuesWorker(ctx, releasesWG, releasesNodesChan, releasesMutex, releasesFails)
 	}
-	//nolint:wrapcheck
-	return wg.Wait()
+
+	if err := releasesWG.WaitWithContext(ctx); err != nil {
+		return err
+	}
+
+	return p.ApplyReport(releasesFails, nil)
+}
+
+//nolint:dupl
+func (p *Plan) buildReleaseValuesWorker(
+	ctx context.Context,
+	wg *parallel.WaitGroup,
+	nodesChan <-chan *dependency.Node[release.Config],
+	mu *sync.Mutex,
+	fails map[release.Config]error,
+) {
+	for node := range nodesChan {
+		rel := node.Data
+		err := p.buildReleaseValues(ctx, rel)
+		if err != nil {
+			if rel.AllowFailure() {
+				rel.Logger().Errorf("release is allowed to fail, marked as succeeded to dependencies")
+				node.SetSucceeded()
+			} else {
+				node.SetFailed()
+			}
+
+			mu.Lock()
+			fails[rel] = err
+			mu.Unlock()
+
+			wg.ErrChan() <- err
+		} else {
+			node.SetSucceeded()
+		}
+	}
+	wg.Done()
 }
 
 func (p *Plan) buildReleaseValues(ctx context.Context, rel release.Config) error {
+	log.Info("🔨 Building release values...")
+
 	err := rel.BuildValues(ctx, p.tmpDir, p.templater)
 	if err != nil {
 		log.Errorf("❌ %s values: %v", rel.Uniq(), err)

--- a/pkg/plan/build_values_internal_test.go
+++ b/pkg/plan/build_values_internal_test.go
@@ -61,6 +61,8 @@ func (ts *BuildValuesTestSuite) TestValuesBuildError() {
 	mockedRelease.On("Values").Return([]release.ValuesReference{
 		{Src: tmpValues},
 	})
+	mockedRelease.On("DependsOn").Return([]*release.DependsOnReference{})
+	mockedRelease.On("AllowFailure").Return(false)
 
 	errBuildValues := errors.New("values build error")
 	mockedRelease.On("BuildValues").Return(errBuildValues)
@@ -91,6 +93,7 @@ func (ts *BuildValuesTestSuite) TestSuccess() {
 	})
 	mockedRelease.On("BuildValues").Return(nil)
 	mockedRelease.On("Uniq").Return()
+	mockedRelease.On("DependsOn").Return([]*release.DependsOnReference{})
 
 	p.body = &planBody{
 		Releases: release.Configs{mockedRelease},

--- a/pkg/plan/export_internal_test.go
+++ b/pkg/plan/export_internal_test.go
@@ -57,6 +57,7 @@ func (ts *ExportTestSuite) TestValuesOneRelease() {
 	mockedRelease.On("BuildValues").Return(nil)
 	mockedRelease.On("KubeContext").Return("")
 	mockedRelease.On("Uniq").Return()
+	mockedRelease.On("DependsOn").Return([]*release.DependsOnReference{})
 
 	p.body = &planBody{
 		Releases: release.Configs{mockedRelease},

--- a/pkg/plan/mock_release_export_test.go
+++ b/pkg/plan/mock_release_export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	gotemplate "text/template"
 
 	"github.com/helmwave/helmwave/pkg/hooks"
 	"github.com/helmwave/helmwave/pkg/monitor"
@@ -91,7 +92,7 @@ func (r *MockReleaseConfig) Equal(_ release.Config) bool {
 	return r.Called().Bool(0)
 }
 
-func (r *MockReleaseConfig) BuildValues(ctx context.Context, dir, templater string) error {
+func (r *MockReleaseConfig) BuildValues(ctx context.Context, dir, templater string, templateFuncs gotemplate.FuncMap) error {
 	args := r.Called()
 	if errReturn := args.Error(0); errReturn != nil {
 		return errReturn

--- a/pkg/plan/template.go
+++ b/pkg/plan/template.go
@@ -1,0 +1,60 @@
+package plan
+
+import (
+	"fmt"
+	"sync"
+
+	gotemplate "text/template"
+
+	"github.com/helmwave/helmwave/pkg/template"
+	"gopkg.in/yaml.v3"
+)
+
+//nolint:gocognit
+func (p *Plan) templateFuncs(mu *sync.Mutex) gotemplate.FuncMap {
+	funcMap := gotemplate.FuncMap{}
+
+	// `getPlan` template function
+	var plan map[string]any
+	funcMap["getPlan"] = func() (map[string]any, error) {
+		if plan == nil {
+			mu.Lock()
+			defer mu.Unlock()
+			planYaml, err := yaml.Marshal(p.body)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal plan: %w", err)
+			}
+			plan, err = template.FromYaml(string(planYaml))
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal plan: %w", err)
+			}
+		}
+
+		return plan, nil
+	}
+
+	// `getManifests` template function
+	var manifests map[string][]any
+	funcMap["getManifests"] = func(release string) ([]any, error) {
+		if manifests == nil {
+			mu.Lock()
+			defer mu.Unlock()
+			manifests = make(map[string][]any)
+			for uniq, manifestYaml := range p.manifests {
+				manifest, err := template.FromYamlAll(manifestYaml)
+				if err != nil {
+					return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+				}
+				manifests[uniq.String()] = manifest
+			}
+		}
+		manifest, found := manifests[release]
+		if !found {
+			return nil, fmt.Errorf("manifests for release %q not found", release)
+		}
+
+		return manifest, nil
+	}
+
+	return funcMap
+}

--- a/pkg/plan/template_internal_test.go
+++ b/pkg/plan/template_internal_test.go
@@ -1,0 +1,189 @@
+package plan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	gotemplate "text/template"
+
+	"github.com/helmwave/helmwave/pkg/release/uniqname"
+	"github.com/helmwave/helmwave/pkg/template"
+	"github.com/stretchr/testify/suite"
+)
+
+type TemplateFuncsTestSuite struct {
+	suite.Suite
+}
+
+func TestTemplateFuncsTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(TemplateFuncsTestSuite))
+}
+
+func (ts *TemplateFuncsTestSuite) renderTemplate(ctx context.Context, tpl string, data any, templateFuncs gotemplate.FuncMap) (string, error) {
+	tmpDir := ts.T().TempDir()
+	tplFile := filepath.Join(tmpDir, "test.tpl")
+	ymlFile := filepath.Join(tmpDir, "test.yml")
+
+	err := os.WriteFile(tplFile, []byte(tpl), 0o600)
+	ts.Require().NoError(err)
+
+	opts := []template.TemplaterOptions{}
+	for name, value := range templateFuncs {
+		opts = append(opts, template.AddFunc(name, value))
+	}
+
+	err = template.Tpl2yml(ctx, tplFile, ymlFile, data, template.TemplaterSprig, opts...)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := os.ReadFile(ymlFile)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
+func (ts *TemplateFuncsTestSuite) TestGetPlan() {
+	p := New(".")
+	body := p.NewBody()
+	body.Project = "my-project"
+	body.Version = "1.0.0"
+
+	mu := &sync.Mutex{}
+	templateFuncs := p.templateFuncs(mu)
+
+	ctx := context.Background()
+	tpl := `{{ $plan := getPlan }}{{ $plan.project }},{{ $plan.version }}`
+
+	data := struct {
+		Release struct {
+			Name string
+		}
+	}{
+		Release: struct {
+			Name string
+		}{
+			Name: "test-release",
+		},
+	}
+
+	rendered, err := ts.renderTemplate(ctx, tpl, data, templateFuncs)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("my-project,1.0.0", rendered)
+}
+
+func (ts *TemplateFuncsTestSuite) TestGetManifestsEmpty() {
+	p := New(".")
+	p.NewBody()
+
+	mu := &sync.Mutex{}
+	templateFuncs := p.templateFuncs(mu)
+
+	ts.Require().NotEmpty(templateFuncs)
+}
+
+func (ts *TemplateFuncsTestSuite) TestGetManifestsSingleDocument() {
+	p := New(".")
+	p.NewBody()
+
+	uniq, _ := uniqname.NewFromString("redis@default")
+	p.manifests[uniq] = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test`
+
+	mu := &sync.Mutex{}
+	templateFuncs := p.templateFuncs(mu)
+
+	ctx := context.Background()
+	tpl := `{{ $manifests := getManifests "redis@default" }}{{ len $manifests }}`
+	rendered, err := ts.renderTemplate(ctx, tpl, nil, templateFuncs)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("1", rendered)
+}
+
+func (ts *TemplateFuncsTestSuite) TestGetManifestsMultipleReleases() {
+	p := New(".")
+	p.NewBody()
+
+	uniq1, _ := uniqname.NewFromString("redis@default")
+	p.manifests[uniq1] = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-svc`
+
+	uniq2, _ := uniqname.NewFromString("nginx@default")
+	p.manifests[uniq2] = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-svc`
+
+	mu := &sync.Mutex{}
+	templateFuncs := p.templateFuncs(mu)
+
+	ctx := context.Background()
+	tpl := `{{ $m1 := getManifests "redis@default" }}{{ $m2 := getManifests "nginx@default" }}{{ len $m1 }},{{ len $m2 }}`
+	rendered, err := ts.renderTemplate(ctx, tpl, nil, templateFuncs)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("2,2", rendered)
+}
+
+func (ts *TemplateFuncsTestSuite) TestGetManifestsContent() {
+	p := New(".")
+	p.NewBody()
+
+	uniq, _ := uniqname.NewFromString("redis@default")
+	p.manifests[uniq] = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-config
+data:
+  key: value`
+
+	mu := &sync.Mutex{}
+	templateFuncs := p.templateFuncs(mu)
+
+	ctx := context.Background()
+	tpl := `{{ $manifests := getManifests "redis@default" }}{{ range $manifests }}{{ .kind }}{{ end }}`
+	rendered, err := ts.renderTemplate(ctx, tpl, nil, templateFuncs)
+	ts.Require().NoError(err)
+
+	ts.Require().Equal("ConfigMap", rendered)
+}
+
+func (ts *TemplateFuncsTestSuite) TestGetManifestsNotFound() {
+	p := New(".")
+	p.NewBody()
+
+	mu := &sync.Mutex{}
+	templateFuncs := p.templateFuncs(mu)
+
+	ctx := context.Background()
+	tpl := `{{ $manifests := getManifests "nonexistent@default" }}`
+
+	_, err := ts.renderTemplate(ctx, tpl, nil, templateFuncs)
+	ts.Require().Error(err)
+	ts.Require().ErrorContains(err, "not found")
+}

--- a/pkg/plan/validate_test.go
+++ b/pkg/plan/validate_test.go
@@ -82,7 +82,7 @@ func (ts *ValidateTestSuite) TestValidateValues() {
 	mockedRelease.On("KubeContext").Return("")
 
 	v := release.ValuesReference{Src: tmpValues}
-	ts.Require().NoError(v.SetViaRelease(ts.ctx, mockedRelease, tmpDir, template.TemplaterSprig, nil))
+	ts.Require().NoError(v.SetViaRelease(ts.ctx, mockedRelease, tmpDir, template.TemplaterSprig, nil, nil))
 
 	mockedRelease.On("Values").Return([]release.ValuesReference{v})
 

--- a/pkg/release/interface.go
+++ b/pkg/release/interface.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"slices"
 
 	"github.com/helmwave/helmwave/pkg/helper"
@@ -28,7 +29,7 @@ type Config interface {
 	HideSecret(hideSecret bool)
 	ChartDepsUpd() error
 	DownloadChart(tmpDir string) error
-	BuildValues(ctx context.Context, dir, templater string) error
+	BuildValues(ctx context.Context, dir, templater string, templateFuncs template.FuncMap) error
 	Name() string
 	Namespace() string
 	Chart() *Chart

--- a/pkg/release/values_test.go
+++ b/pkg/release/values_test.go
@@ -104,7 +104,7 @@ func (ts *ValuesTestSuite) TestBuildNonExistingNonStrict() {
 		},
 	}
 
-	err := r.BuildValues(ts.ctx, ".", template.TemplaterSprig)
+	err := r.BuildValues(ts.ctx, ".", template.TemplaterSprig, nil)
 
 	ts.Require().NoError(err)
 	ts.Require().Empty(r.Values())
@@ -119,7 +119,7 @@ func (ts *ValuesTestSuite) TestBuildNonExistingStrict() {
 		},
 	}
 
-	err := r.BuildValues(ts.ctx, ".", template.TemplaterSprig)
+	err := r.BuildValues(ts.ctx, ".", template.TemplaterSprig, nil)
 
 	ts.Require().Error(err)
 }


### PR DESCRIPTION
### Description

Add two new template functions for values rendering, enabling releases to access plan-level information and their dependencies' built artifacts.

### New Template Functions

**`getPlan`**
- Access the full plan configuration from `helmwave.yml`
- Releases can enumerate all releases and extract information
- Releases can leverage the `store` field to share custom data across values

**`getManifests(release)`**
- Fetch rendered manifests of a depending release
- Useful when a dependency chart generates random secrets (e.g., passwords, tokens) that downstream releases need to reference

### Example

```yaml
# helmwave.yml
releases:
  - name: redis
    store:
      port: 6379
  - name: app
    depends_on:
      - redis@default

# app values.yaml.tpl
{{ $plan := getPlan }}
{{ $manifests := getManifests "redis@default" }}
redisPort: {{ ($plan.releases | first).store.port }}
redisSecret: {{ (index $manifests 0).data.password }}
```

---

Depends on https://github.com/helmwave/helmwave/pull/1183