### PR TITLE
fix: refine dry-run=server option to not apply when `offlineKubeVersion` is specified

### DIFF
--- a/pkg/release/helm_actions.go
+++ b/pkg/release/helm_actions.go
@@ -68,13 +68,14 @@ func (rel *config) newInstall() *action.Install {
 	}
 
 	if client.DryRun {
-		client.DryRunOption = "server"
 		client.Replace = true
 	}
 
 	if client.DryRun && nil != rel.OfflineKubeVersion() {
 		client.ClientOnly = true
 		client.KubeVersion = rel.OfflineKubeVersion()
+	} else {
+		client.DryRunOption = "server"
 	}
 
 	return client


### PR DESCRIPTION
This PR refines the dry-run behavior when `offlineKubeVersion` is specified:

**Changes:**
- Move `client.DryRunOption = "server"` to only apply when NOT using offline kube version
- When `offlineKubeVersion` is set, the client operates in client-only mode and should not use server-side dry-run