### PR TITLE
fix: only set `client.DryRunOption` when `client.DryRun` is enabled

### DIFF
--- a/pkg/release/helm_actions.go
+++ b/pkg/release/helm_actions.go
@@ -69,13 +69,13 @@ func (rel *config) newInstall() *action.Install {
 
 	if client.DryRun {
 		client.Replace = true
-	}
-
-	if client.DryRun && nil != rel.OfflineKubeVersion() {
-		client.ClientOnly = true
-		client.KubeVersion = rel.OfflineKubeVersion()
-	} else {
-		client.DryRunOption = "server"
+		if rel.OfflineKubeVersion() != nil {
+			client.DryRunOption = "client"
+			client.ClientOnly = true
+			client.KubeVersion = rel.OfflineKubeVersion()
+		} else {
+			client.DryRunOption = "server"
+		}
 	}
 
 	return client


### PR DESCRIPTION
My bad, setting `client.DryRunOption` also enables helm dry-run mode even if `client.DryRun` is not set...