### PR TITLE
feat: add `getTags` template function

### DIFF
--- a/pkg/plan/build.go
+++ b/pkg/plan/build.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"context"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -26,6 +27,17 @@ func (p *Plan) Build(ctx context.Context, o BuildOptions) (err error) {
 		return
 	}
 	p.body = body
+
+	// Calculate tags
+	tags := o.Tags
+	if len(tags) == 0 {
+		for _, rel := range p.body.Releases {
+			tags = append(tags, rel.Tags()...)
+		}
+		slices.Sort(tags)
+		tags = slices.Compact(tags)
+	}
+	p.tags = tags
 
 	// Run Pre hooks
 	err = p.body.Lifecycle.RunPreBuild(ctx)

--- a/pkg/plan/new.go
+++ b/pkg/plan/new.go
@@ -46,6 +46,7 @@ type Plan struct {
 	tmpDir    string
 	graphMD   string
 	templater string
+	tags      []string
 
 	manifests map[uniqname.UniqName]string
 	values    map[uniqname.UniqName]map[string]string

--- a/pkg/plan/template.go
+++ b/pkg/plan/template.go
@@ -14,6 +14,12 @@ import (
 func (p *Plan) templateFuncs(mu *sync.Mutex) gotemplate.FuncMap {
 	funcMap := gotemplate.FuncMap{}
 
+	// `getTags` template function
+	tags := p.tags
+	funcMap["getTags"] = func() []string {
+		return tags
+	}
+
 	// `getPlan` template function
 	var plan map[string]any
 	funcMap["getPlan"] = func() (map[string]any, error) {


### PR DESCRIPTION
If not tag is provided in command line, collect all tags in plan and return.

Example:

For prometheus to install crd only, we use a `crd` tag:
```helm
{{- if getTags | len | eq 1 | and (getTags | first | eq "crd") }}
prometheusOperator:
  enabled: false

prometheus:
  enabled: false

alertmanager:
  enabled: false

defaultRules:
  create: false

kubernetesServiceMonitors:
  enabled: false

kubeStateMetrics:
  enabled: false

nodeExporter:
  enabled: false

grafana:
  enabled: false
{{- end }}
```