### PR TITLE
feat: allow indexing values with base filename in `getValues`

### DIFF
--- a/pkg/plan/template.go
+++ b/pkg/plan/template.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"path/filepath"
 	"sync"
 
 	gotemplate "text/template"
@@ -71,6 +72,7 @@ func (p *Plan) templateFuncs(mu *sync.Mutex) gotemplate.FuncMap {
 						return nil, fmt.Errorf("failed to unmarshal value: %w", err)
 					}
 					releaseValues[filename] = value
+					releaseValues[filepath.Base(filename)] = value
 				}
 				values[uniq.String()] = releaseValues
 			}

--- a/pkg/plan/template_internal_test.go
+++ b/pkg/plan/template_internal_test.go
@@ -194,14 +194,14 @@ func (ts *TemplateFuncsTestSuite) TestGetValuesCrossRelease() {
 
 	uniq1, _ := uniqname.NewFromString("redis@default")
 	p.values[uniq1] = map[string]string{
-		"config.yaml": `redis:
+		"values/redis.yaml": `redis:
   host: redis.example.com
   port: 6379`,
 	}
 
 	uniq2, _ := uniqname.NewFromString("nginx@default")
 	p.values[uniq2] = map[string]string{
-		"config.yaml": `nginx:
+		"values/nginx.yaml": `nginx:
   port: 80`,
 	}
 
@@ -209,7 +209,7 @@ func (ts *TemplateFuncsTestSuite) TestGetValuesCrossRelease() {
 	templateFuncs := p.templateFuncs(mu)
 
 	ctx := context.Background()
-	tpl := `{{ $redis := getValues "redis@default" "config.yaml" }}{{ $nginx := getValues "nginx@default" "config.yaml" }}{{ $redis.redis.host }}:{{ $nginx.nginx.port }}`
+	tpl := `{{ $redis := getValues "redis@default" "values/redis.yaml" }}{{ $nginx := getValues "nginx@default" "nginx.yaml" }}{{ $redis.redis.host }}:{{ $nginx.nginx.port }}`
 	rendered, err := ts.renderTemplate(ctx, tpl, nil, templateFuncs)
 	ts.Require().NoError(err)
 


### PR DESCRIPTION
This would be helpful when a value file's path is dynamic during `helmwave yml` rendering, while the base filename keeps stable.

Multiple value files of same basename is undefined behavior (either one overrides another during map construction). Users definitely know what they're doing when using `getValues` in this form.