### PR TITLE
feat: implement dedicated kustomize post-renderer

### DIFF
--- a/.changes/unreleased/New feature-20260220-120104.yaml
+++ b/.changes/unreleased/New feature-20260220-120104.yaml
@@ -1,0 +1,6 @@
+kind: New feature
+body: 'feat: implement dedicated kustomize post-renderer'
+time: 2026-02-20T12:01:04.791217652+08:00
+custom:
+    Author: Vigilans
+    Issue: "1189"

--- a/pkg/plan/build_manifests.go
+++ b/pkg/plan/build_manifests.go
@@ -92,6 +92,11 @@ func (p *Plan) buildReleaseManifest(ctx context.Context, rel release.Config, mu 
 		return err
 	}
 
+	err = p.buildReleasePostRenderer(ctx, rel, mu)
+	if err != nil {
+		return err
+	}
+
 	r, err := rel.SyncDryRun(ctx, false)
 	if err != nil || r == nil {
 		l.Errorf("❌ can't get manifests: %v", err)

--- a/pkg/plan/build_manifests_internal_test.go
+++ b/pkg/plan/build_manifests_internal_test.go
@@ -53,6 +53,7 @@ func (ts *BuildManifestsTestSuite) TestMultipleReleases() {
 	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel1.On("BuildValues").Return(map[string]string{}, nil)
 	rel1.On("Values").Return([]release.ValuesReference{})
+	rel1.On("BuildPostRenderer").Return(nil)
 
 	rel2 := NewMockReleaseConfig(ts.T())
 	u2, _ := uniqname.NewFromString("redis2@defaultblabla")
@@ -65,6 +66,7 @@ func (ts *BuildManifestsTestSuite) TestMultipleReleases() {
 	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel2.On("BuildValues").Return(map[string]string{}, nil)
 	rel2.On("Values").Return([]release.ValuesReference{})
+	rel2.On("BuildPostRenderer").Return(nil)
 
 	p.SetReleases(rel1, rel2)
 
@@ -96,6 +98,7 @@ func (ts *BuildManifestsTestSuite) TestChartDepsUpdError() {
 	rel.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel.On("BuildValues").Return(map[string]string{}, nil)
 	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("BuildPostRenderer").Return(nil)
 
 	p.SetReleases(rel)
 
@@ -123,6 +126,7 @@ func (ts *BuildManifestsTestSuite) TestSyncError() {
 	rel.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel.On("BuildValues").Return(map[string]string{}, nil)
 	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("BuildPostRenderer").Return(nil)
 	rel.On("AllowFailure").Return(false)
 
 	p.SetReleases(rel)
@@ -151,6 +155,7 @@ func (ts *BuildManifestsTestSuite) TestDisabledHooks() {
 	rel.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel.On("BuildValues").Return(map[string]string{}, nil)
 	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("BuildPostRenderer").Return(nil)
 
 	p.SetReleases(rel)
 
@@ -186,6 +191,7 @@ func (ts *BuildManifestsTestSuite) TestEnabledHooks() {
 	rel.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel.On("BuildValues").Return(map[string]string{}, nil)
 	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("BuildPostRenderer").Return(nil)
 
 	p.SetReleases(rel)
 
@@ -219,6 +225,7 @@ func (ts *BuildManifestsTestSuite) TestReleasesWithDependency() {
 	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel1.On("BuildValues").Return(map[string]string{}, nil)
 	rel1.On("Values").Return([]release.ValuesReference{})
+	rel1.On("BuildPostRenderer").Return(nil)
 
 	// rel2 depends on rel1
 	rel2 := NewMockReleaseConfig(ts.T())
@@ -236,6 +243,7 @@ func (ts *BuildManifestsTestSuite) TestReleasesWithDependency() {
 	rel2.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel2.On("BuildValues").Return(map[string]string{}, nil)
 	rel2.On("Values").Return([]release.ValuesReference{})
+	rel2.On("BuildPostRenderer").Return(nil)
 
 	// Pass in reverse order to verify dependency graph corrects the order
 	p.SetReleases(rel2, rel1)
@@ -271,6 +279,7 @@ func (ts *BuildManifestsTestSuite) TestReleasesWithDependencyFailure() {
 	rel1.On("Lifecycle").Return(hooks.Lifecycle{})
 	rel1.On("BuildValues").Return(map[string]string{}, nil)
 	rel1.On("Values").Return([]release.ValuesReference{})
+	rel1.On("BuildPostRenderer").Return(nil)
 	rel1.On("AllowFailure").Return(false)
 
 	// rel2 depends on rel1, should NOT be built because rel1 fails

--- a/pkg/plan/build_post_renderer.go
+++ b/pkg/plan/build_post_renderer.go
@@ -1,0 +1,28 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/helmwave/helmwave/pkg/release"
+)
+
+func (p *Plan) buildReleasePostRenderer(ctx context.Context, rel release.Config, mu *sync.Mutex) error {
+	templateFuncs := p.templateFuncs(mu)
+
+	if getValuesFunc, ok := templateFuncs["getValues"].(func(string, string) (any, error)); ok {
+		templateFuncs["getValues"] = func(args ...string) (any, error) {
+			switch len(args) {
+			case 1:
+				return getValuesFunc(rel.Uniq().String(), args[0])
+			case 2:
+				return getValuesFunc(args[0], args[1])
+			default:
+				return nil, fmt.Errorf("getValues requires 1 or 2 arguments")
+			}
+		}
+	}
+
+	return rel.BuildPostRenderer(ctx, p.tmpDir, p.templater, templateFuncs)
+}

--- a/pkg/plan/build_post_renderer_internal_test.go
+++ b/pkg/plan/build_post_renderer_internal_test.go
@@ -1,0 +1,77 @@
+package plan
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/helmwave/helmwave/pkg/hooks"
+	"github.com/helmwave/helmwave/pkg/release"
+	"github.com/helmwave/helmwave/pkg/release/uniqname"
+	"github.com/helmwave/helmwave/tests"
+	"github.com/stretchr/testify/suite"
+	helmRelease "helm.sh/helm/v3/pkg/release"
+)
+
+type BuildPostRendererTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestBuildPostRendererTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(BuildPostRendererTestSuite))
+}
+
+func (ts *BuildPostRendererTestSuite) SetupTest() {
+	ts.ctx = tests.GetContext(ts.T())
+}
+
+func (ts *BuildPostRendererTestSuite) TestSuccess() {
+	p := New(".")
+
+	rel := NewMockReleaseConfig(ts.T())
+	uniq, _ := uniqname.NewFromString("redis@default")
+	rel.On("ChartDepsUpd").Return(nil)
+	rel.On("DryRun").Return()
+	rel.On("Sync").Return(&helmRelease.Release{}, nil)
+	rel.On("HooksDisabled").Return(false)
+	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+	rel.On("BuildValues").Return(map[string]string{}, nil)
+	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("BuildPostRenderer").Return(nil)
+
+	p.SetReleases(rel)
+
+	err := p.buildManifest(ts.ctx)
+
+	ts.Require().NoError(err)
+	rel.AssertCalled(ts.T(), "BuildPostRenderer")
+}
+
+func (ts *BuildPostRendererTestSuite) TestBuildError() {
+	p := New(".")
+
+	errBuild := errors.New("post-renderer build error")
+
+	rel := NewMockReleaseConfig(ts.T())
+	uniq, _ := uniqname.NewFromString("redis@default")
+	rel.On("ChartDepsUpd").Return(nil)
+	rel.On("Uniq").Return(uniq)
+	rel.On("DependsOn").Return([]*release.DependsOnReference{})
+	rel.On("AllowFailure").Return(false)
+	rel.On("Values").Return([]release.ValuesReference{})
+	rel.On("BuildValues").Return(map[string]string{}, nil)
+	rel.On("BuildPostRenderer").Return(errBuild)
+	rel.On("Lifecycle").Return(hooks.Lifecycle{})
+
+	p.SetReleases(rel)
+
+	err := p.buildManifest(ts.ctx)
+
+	ts.Require().ErrorIs(err, errBuild)
+	rel.AssertCalled(ts.T(), "BuildPostRenderer")
+}

--- a/pkg/plan/export.go
+++ b/pkg/plan/export.go
@@ -15,6 +15,8 @@ import (
 )
 
 // Export allows save plan to file.
+//
+//nolint:gocognit
 func (p *Plan) Export(ctx context.Context, skipUnchanged bool) error {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -39,7 +41,7 @@ func (p *Plan) Export(ctx context.Context, skipUnchanged bool) error {
 	}
 
 	wg := parallel.NewWaitGroup()
-	wg.Add(4)
+	wg.Add(5)
 
 	go func() {
 		defer wg.Done()
@@ -56,6 +58,12 @@ func (p *Plan) Export(ctx context.Context, skipUnchanged bool) error {
 	go func() {
 		defer wg.Done()
 		if err := p.exportValues(); err != nil {
+			wg.ErrChan() <- err
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if err := p.exportKustomize(); err != nil {
 			wg.ErrChan() <- err
 		}
 	}()
@@ -195,6 +203,32 @@ func (p *Plan) exportValues() error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to copy values from %s to %s: %w", p.tmpDir, p.dir, err)
+	}
+
+	return nil
+}
+
+func (p *Plan) exportKustomize() error {
+	found := false
+
+	for _, rel := range p.body.Releases {
+		pr := rel.PostRenderer()
+		if pr != nil && pr.Kustomize != nil {
+			found = true
+			pr.Kustomize.SetUniq(p.dir, rel.Uniq())
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	err := helper.MoveFile(
+		filepath.Join(p.tmpDir, "kustomize"),
+		filepath.Join(p.dir, "kustomize"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to move kustomize from %s to %s: %w", p.tmpDir, p.dir, err)
 	}
 
 	return nil

--- a/pkg/plan/mock_release_export_test.go
+++ b/pkg/plan/mock_release_export_test.go
@@ -110,6 +110,21 @@ func (r *MockReleaseConfig) BuildValues(ctx context.Context, dir, templater stri
 	return map[string]string{}, nil
 }
 
+func (r *MockReleaseConfig) BuildPostRenderer(_ context.Context, _, _ string, _ gotemplate.FuncMap) error {
+	args := r.Called()
+
+	return args.Error(0)
+}
+
+func (r *MockReleaseConfig) PostRenderer() *release.PostRendererReference {
+	args := r.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+
+	return args.Get(0).(*release.PostRendererReference)
+}
+
 func (r *MockReleaseConfig) Uninstall(context.Context) (*helmRelease.UninstallReleaseResponse, error) {
 	args := r.Called()
 

--- a/pkg/release/config.go
+++ b/pkg/release/config.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/chartutil"
 	helm "helm.sh/helm/v3/pkg/cli"
-	"helm.sh/helm/v3/pkg/postrender"
 )
 
 type configTests struct {
@@ -20,6 +19,7 @@ type configTests struct {
 	ForceShowLogs bool                `yaml:"force_show_logs,omitempty" json:"force_show_logs,omitempty" jsonschema:"description=Always show tests logs, not only if they failed,default=false"`
 }
 
+//nolint:govet // field order is more important than alignment
 type config struct {
 	helm *helm.EnvSettings
 	log  *log.Entry
@@ -38,13 +38,13 @@ type config struct {
 	KubeContextF        string `yaml:"context,omitempty" json:"context,omitempty"`
 	DeletePropagation   string `yaml:"delete_propagation,omitempty" json:"delete_propagation,omitempty" jsonschema:"description=Selects the deletion cascading strategy for the dependents,enum=background,enum=orphan,enum=foreground,default=background"`
 
-	DependsOnF    []*DependsOnReference `yaml:"depends_on,omitempty" json:"depends_on,omitempty" jsonschema:"title=Needs,description=List of dependencies that are required to succeed before this release"`
-	MonitorsF     []MonitorReference    `yaml:"monitors,omitempty" json:"monitors,omitempty" jsonschema:"title=Monitors to execute after upgrade"`
-	ValuesF       []ValuesReference     `yaml:"values,omitempty" json:"values,omitempty" jsonschema:"title=Values of the release"`
-	TagsF         []string              `yaml:"tags,omitempty" json:"tags,omitempty" jsonschema:"description=Tags allows you choose releases for build"`
-	Labels        map[string]string     `yaml:"labels,omitempty" json:"labels,omitempty" jsonschema:"Labels that would be added to release metadata on sync"`
-	PostRendererF []string              `yaml:"post_renderer,omitempty" json:"post_renderer,omitempty" jsonschema:"description=List of post_renders to manipulate with manifests"`
-	Timeout       time.Duration         `yaml:"timeout,omitempty" json:"timeout,omitempty" jsonschema:"oneof_type=string;integer,default=5m"`
+	DependsOnF    []*DependsOnReference  `yaml:"depends_on,omitempty" json:"depends_on,omitempty" jsonschema:"title=Needs,description=List of dependencies that are required to succeed before this release"`
+	MonitorsF     []MonitorReference     `yaml:"monitors,omitempty" json:"monitors,omitempty" jsonschema:"title=Monitors to execute after upgrade"`
+	ValuesF       []ValuesReference      `yaml:"values,omitempty" json:"values,omitempty" jsonschema:"title=Values of the release"`
+	TagsF         []string               `yaml:"tags,omitempty" json:"tags,omitempty" jsonschema:"description=Tags allows you choose releases for build"`
+	Labels        map[string]string      `yaml:"labels,omitempty" json:"labels,omitempty" jsonschema:"Labels that would be added to release metadata on sync"`
+	PostRendererF *PostRendererReference `yaml:"post_renderer,omitempty" json:"post_renderer,omitempty" jsonschema:"description=Post-renderer configuration to manipulate with manifests"`
+	Timeout       time.Duration          `yaml:"timeout,omitempty" json:"timeout,omitempty" jsonschema:"oneof_type=string;integer,default=5m"`
 
 	// Lock for parallel testing
 	lock sync.RWMutex
@@ -232,12 +232,8 @@ func (rel *config) buildAfterUnmarshalDependency(dep *DependsOnReference) error 
 	return u.Validate()
 }
 
-func (rel *config) PostRenderer() (postrender.PostRenderer, error) {
-	if len(rel.PostRendererF) < 1 {
-		return nil, nil //nolint:nilnil
-	}
-
-	return postrender.NewExec(rel.PostRendererF[0], rel.PostRendererF[1:]...) //nolint:wrapcheck
+func (rel *config) PostRenderer() *PostRendererReference {
+	return rel.PostRendererF
 }
 
 func (rel *config) KubeContext() string {

--- a/pkg/release/helm_actions.go
+++ b/pkg/release/helm_actions.go
@@ -60,7 +60,7 @@ func (rel *config) newInstall() *action.Install {
 	client.SubNotes = rel.SubNotes
 	client.Description = rel.Description()
 
-	pr, err := rel.PostRenderer()
+	pr, err := rel.PostRenderer().HelmPostRenderer()
 	if err != nil {
 		rel.Logger().WithError(err).Warn("failed to create post-renderer")
 	} else {
@@ -114,7 +114,7 @@ func (rel *config) newUpgrade() *action.Upgrade {
 	client.SubNotes = rel.SubNotes
 	client.Description = rel.Description()
 
-	pr, err := rel.PostRenderer()
+	pr, err := rel.PostRenderer().HelmPostRenderer()
 	if err != nil {
 		rel.Logger().WithError(err).Warn("failed to create post_renderer")
 	} else {

--- a/pkg/release/interface.go
+++ b/pkg/release/interface.go
@@ -30,6 +30,7 @@ type Config interface {
 	ChartDepsUpd() error
 	DownloadChart(tmpDir string) error
 	BuildValues(ctx context.Context, dir, templater string, templateFuncs template.FuncMap) (map[string]string, error)
+	BuildPostRenderer(ctx context.Context, dir, templater string, templateFuncs template.FuncMap) error
 	Name() string
 	Namespace() string
 	Chart() *Chart
@@ -39,6 +40,7 @@ type Config interface {
 	Tags() []string
 	Repo() string
 	Values() []ValuesReference
+	PostRenderer() *PostRendererReference
 	HelmWait() bool
 	KubeContext() string
 	Cfg() *action.Configuration

--- a/pkg/release/post_renderer.go
+++ b/pkg/release/post_renderer.go
@@ -1,0 +1,355 @@
+package release
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	gotemplate "text/template"
+
+	"github.com/google/shlex"
+	"github.com/helmwave/helmwave/pkg/helper"
+	"github.com/helmwave/helmwave/pkg/release/uniqname"
+	"github.com/helmwave/helmwave/pkg/template"
+	"github.com/invopop/jsonschema"
+	cp "github.com/otiai10/copy"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+	"helm.sh/helm/v3/pkg/postrender"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+// PostRendererReference supports exec and kustomize modes for post-rendering.
+// Only one of Exec or Kustomize should be set.
+//
+//nolint:lll
+type PostRendererReference struct {
+	Kustomize *KustomizeConfig `yaml:"kustomize,omitempty" json:"kustomize,omitempty" jsonschema:"description=Kustomize directory for post-rendering"`
+	Exec      ExecConfig       `yaml:"exec,omitempty" json:"exec,omitempty" jsonschema:"description=Command to execute for post-rendering"`
+}
+
+// ExecConfig represents a command to execute.
+// Supports both string (will be split using shlex) and array formats.
+type ExecConfig []string
+
+// KustomizeConfig specifies a kustomization directory for post-rendering.
+//
+//nolint:lll
+type KustomizeConfig struct {
+	Src            string `yaml:"src" json:"src" jsonschema:"required,description=Source directory path containing kustomization.yaml"`
+	Dst            string `yaml:"dst" json:"dst" jsonschema:"readOnly,description=Rendered destination directory"`
+	DelimiterLeft  string `yaml:"delimiter_left,omitempty" json:"delimiter_left,omitempty" jsonschema:"Set left delimiter for template engine,default={{"`
+	DelimiterRight string `yaml:"delimiter_right,omitempty" json:"delimiter_right,omitempty" jsonschema:"Set right delimiter for template engine,default=}}"`
+	Renderer       string `yaml:"renderer" json:"renderer" jsonschema:"description=How to render the files,enum=sprig,enum=gomplate,enum=copy,default=sprig"`
+}
+
+func (p PostRendererReference) JSONSchema() *jsonschema.Schema {
+	// Use reflector for the object format, and manually add array format as OneOf
+	r := &jsonschema.Reflector{
+		DoNotReference:             true,
+		RequiredFromJSONSchemaTags: true,
+	}
+
+	type postRendererReference PostRendererReference
+	objectSchema := r.Reflect(postRendererReference(p))
+
+	return &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{
+				Type:        "array",
+				Items:       &jsonschema.Schema{Type: "string"},
+				Description: "Legacy format: command and arguments as array",
+			},
+			objectSchema,
+		},
+	}
+}
+
+// UnmarshalYAML implements custom unmarshaling for PostRendererReference.
+// Supports both legacy array format and new object format.
+func (p *PostRendererReference) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.SequenceNode:
+		// Legacy format: post_renderer: ["cmd", "arg1", "arg2"]
+		var args []string
+		if err := node.Decode(&args); err != nil {
+			return fmt.Errorf("failed to decode post_renderer array: %w", err)
+		}
+		p.Exec = args
+
+		return nil
+
+	case yaml.MappingNode:
+		// New object format: post_renderer: { exec: ... } or { kustomize: ... }
+		type raw PostRendererReference
+		if err := node.Decode((*raw)(p)); err != nil {
+			return fmt.Errorf("failed to decode post_renderer object: %w", err)
+		}
+
+		// Validate mutual exclusivity
+		if len(p.Exec) > 0 && p.Kustomize != nil {
+			return fmt.Errorf("post_renderer: exec and kustomize are mutually exclusive")
+		}
+
+		return nil
+
+	default:
+		return fmt.Errorf("post_renderer must be an array or object, got %v", node.Kind)
+	}
+}
+
+// UnmarshalYAML implements custom unmarshaling for ExecConfig.
+// Supports both string (shlex split) and array formats.
+func (e *ExecConfig) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		// String format: exec: "./script.sh --arg1 --arg2"
+		var cmd string
+		if err := node.Decode(&cmd); err != nil {
+			return fmt.Errorf("failed to decode exec string: %w", err)
+		}
+		args, err := shlex.Split(cmd)
+		if err != nil {
+			return fmt.Errorf("failed to parse exec command %q: %w", cmd, err)
+		}
+		*e = args
+
+		return nil
+
+	case yaml.SequenceNode:
+		// Array format: exec: ["./script.sh", "--arg1", "--arg2"]
+		var args []string
+		if err := node.Decode(&args); err != nil {
+			return fmt.Errorf("failed to decode exec array: %w", err)
+		}
+		*e = args
+
+		return nil
+
+	default:
+		return fmt.Errorf("exec must be a string or array, got %v", node.Kind)
+	}
+}
+
+// UnmarshalYAML implements custom unmarshaling for KustomizeConfig.
+// Supports both string (directory path) and object formats.
+func (k *KustomizeConfig) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		// String format: kustomize: "path/to/dir"
+		return node.Decode(&k.Src)
+
+	case yaml.MappingNode:
+		// Object format: kustomize: { dir: "path/to/dir", renderer: "sprig" }
+		type raw KustomizeConfig
+
+		return node.Decode((*raw)(k))
+
+	default:
+		return fmt.Errorf("kustomize must be a string or object, got %v", node.Kind)
+	}
+}
+
+// IsEmpty returns true if no post-renderer is configured.
+func (p *PostRendererReference) IsEmpty() bool {
+	return p == nil || (len(p.Exec) == 0 && p.Kustomize == nil)
+}
+
+func (p *PostRendererReference) HelmPostRenderer() (postrender.PostRenderer, error) {
+	if p.IsEmpty() {
+		return nil, nil //nolint:nilnil
+	}
+
+	if len(p.Exec) > 0 {
+		return postrender.NewExec(p.Exec[0], p.Exec[1:]...) //nolint:wrapcheck
+	}
+
+	if p.Kustomize != nil {
+		return newKustomizeRenderer(p.Kustomize), nil
+	}
+
+	return nil, nil //nolint:nilnil
+}
+
+// SetUniq generates unique file path based on provided base directory and release uniqname.
+func (k *KustomizeConfig) SetUniq(dir string, name uniqname.UniqName) {
+	k.Dst = filepath.Join(dir, "kustomize", name.String())
+}
+
+// Build renders the kustomize directory to tmpDir.
+// Must be called before PostRenderer() if kustomize mode is used.
+func (k *KustomizeConfig) Build(
+	ctx context.Context,
+	rel Config,
+	tmpDir, templater string,
+	templateFuncs gotemplate.FuncMap,
+) error {
+	log.Info("🔨 Building release kustomize...")
+
+	l := rel.Logger().WithField("kustomize src", k.Src)
+
+	// Check source directory exists
+	if !helper.IsExists(k.Src) {
+		return fmt.Errorf("kustomize directory %q does not exist", k.Src)
+	}
+
+	// Generate unique destination path
+	k.Dst = filepath.Join(tmpDir, "kustomize", rel.Uniq().String())
+
+	l = l.WithField("kustomize dst", k.Dst)
+
+	// Copy directory to tmpDir
+	if err := cp.Copy(k.Src, k.Dst); err != nil {
+		return fmt.Errorf("failed to copy kustomize directory %q to %q: %w", k.Src, k.Dst, err)
+	}
+
+	// Determine renderer
+	renderer := k.Renderer
+	if renderer == "" {
+		renderer = templater
+	}
+
+	// Set default delimiters for gomplate
+	delimLeft := k.DelimiterLeft
+	delimRight := k.DelimiterRight
+	if renderer == template.TemplaterGomplate && delimLeft == "" && delimRight == "" {
+		delimLeft = "[["
+		delimRight = "]]"
+	}
+
+	// Template data
+	data := struct {
+		Release Config
+	}{
+		Release: rel,
+	}
+
+	opts := []template.TemplaterOptions{
+		template.SetDelimiters(delimLeft, delimRight),
+	}
+	for name, value := range templateFuncs {
+		opts = append(opts, template.AddFunc(name, value))
+	}
+
+	// Render all files in the directory
+	err := filepath.Walk(k.Dst, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		l.WithField("file", path).Trace("Rendering kustomize file")
+
+		return template.Tpl2yml(ctx, path, path, data, renderer, opts...)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to render kustomize directory: %w", err)
+	}
+
+	return nil
+}
+
+// kustomizeRenderer implements helm's PostRenderer interface using kustomize.
+type kustomizeRenderer struct {
+	config *KustomizeConfig
+}
+
+// newKustomizeRenderer creates a new kustomize post-renderer.
+func newKustomizeRenderer(config *KustomizeConfig) *kustomizeRenderer {
+	return &kustomizeRenderer{
+		config: config,
+	}
+}
+
+// Run implements postrender.PostRenderer interface.
+// It writes helm output to all.yaml, injects it into kustomization and runs kustomize build.
+func (r *kustomizeRenderer) Run(renderedManifests *bytes.Buffer) (*bytes.Buffer, error) {
+	fSys := filesys.MakeFsOnDisk()
+
+	// Save helm manifests and inject into kustomization
+	if err := r.AddHelmManifests(renderedManifests, fSys); err != nil {
+		return nil, fmt.Errorf("failed to add helm manifests to kustomization: %w", err)
+	}
+
+	// Run kustomize build using krusty API
+	kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
+	resMap, err := kustomizer.Run(fSys, r.config.Dst)
+	if err != nil {
+		return nil, fmt.Errorf("kustomize build failed in %s: %w", r.config.Dst, err)
+	}
+
+	yamlBytes, err := resMap.AsYaml()
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert kustomize output to YAML: %w", err)
+	}
+
+	log.WithField("dir", r.config.Dst).Debug("Kustomize build completed")
+
+	return bytes.NewBuffer(yamlBytes), nil
+}
+
+// AddHelmManifests performs a `kustomize edit add resource all.yaml` operation to inject helm manifests into kustomization.
+func (r *kustomizeRenderer) AddHelmManifests(renderedManifests *bytes.Buffer, fSys filesys.FileSystem) error {
+	kustomizeRoot := filesys.ConfirmedDir(r.config.Dst)
+	var kustomizeFile string
+	for _, kfilename := range konfig.RecognizedKustomizationFileNames() {
+		if fSys.Exists(kustomizeRoot.Join(kfilename)) {
+			kustomizeFile = kustomizeRoot.Join(kfilename)
+
+			break
+		}
+	}
+
+	// Read kustomization file
+	data, err := fSys.ReadFile(kustomizeFile)
+	if err != nil {
+		return err
+	}
+	var k types.Kustomization
+	if err := k.Unmarshal(data); err != nil {
+		return err
+	}
+	k.FixKustomization()
+
+	// Inject helm manifests into kustomization config if not present
+	var allYamlFile string
+	switch {
+	case slices.Index(k.Resources, "all.yaml") != -1:
+		allYamlFile = "all.yaml"
+	case slices.Index(k.Resources, "all.yml") != -1:
+		allYamlFile = "all.yml"
+	default:
+		allYamlFile = fmt.Sprintf("all%s", filepath.Ext(kustomizeFile))
+		k.Resources = append([]string{allYamlFile}, k.Resources...)
+		data, err = yaml.Marshal(&k)
+		if err != nil {
+			return err
+		}
+		if err := fSys.WriteFile(kustomizeFile, data); err != nil {
+			return err
+		}
+	}
+
+	// Write helm output to all.yaml/all.yml (default to kustomization file extension)
+	return os.WriteFile(kustomizeRoot.Join(allYamlFile), renderedManifests.Bytes(), os.FileMode(0o644))
+}
+
+func (rel *config) BuildPostRenderer(ctx context.Context, tmpDir, templater string, templateFuncs gotemplate.FuncMap) error {
+	if rel.PostRendererF == nil {
+		return nil
+	}
+
+	if rel.PostRendererF.Kustomize != nil {
+		return rel.PostRendererF.Kustomize.Build(ctx, rel, tmpDir, templater, templateFuncs)
+	}
+
+	return nil
+}

--- a/pkg/release/post_renderer_test.go
+++ b/pkg/release/post_renderer_test.go
@@ -1,0 +1,131 @@
+package release_test
+
+import (
+	"testing"
+
+	"github.com/helmwave/helmwave/pkg/release"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+)
+
+type PostRendererTestSuite struct {
+	suite.Suite
+}
+
+func TestPostRendererTestSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(PostRendererTestSuite))
+}
+
+func (ts *PostRendererTestSuite) TestUnmarshalLegacyArray() {
+	var cfg release.PostRendererReference
+	str := `["./script.sh", "--arg1", "--arg2"]`
+
+	err := yaml.Unmarshal([]byte(str), &cfg)
+
+	ts.Require().NoError(err)
+	ts.Require().Equal(release.ExecConfig{"./script.sh", "--arg1", "--arg2"}, cfg.Exec)
+	ts.Require().Nil(cfg.Kustomize)
+}
+
+func (ts *PostRendererTestSuite) TestUnmarshalExecString() {
+	var cfg release.PostRendererReference
+	str := `exec: "./script.sh --arg1 --arg2"`
+
+	err := yaml.Unmarshal([]byte(str), &cfg)
+
+	ts.Require().NoError(err)
+	ts.Require().Equal(release.ExecConfig{"./script.sh", "--arg1", "--arg2"}, cfg.Exec)
+	ts.Require().Nil(cfg.Kustomize)
+}
+
+func (ts *PostRendererTestSuite) TestUnmarshalExecArray() {
+	var cfg release.PostRendererReference
+	str := `exec: ["./script.sh", "--arg1", "--arg2"]`
+
+	err := yaml.Unmarshal([]byte(str), &cfg)
+
+	ts.Require().NoError(err)
+	ts.Require().Equal(release.ExecConfig{"./script.sh", "--arg1", "--arg2"}, cfg.Exec)
+	ts.Require().Nil(cfg.Kustomize)
+}
+
+func (ts *PostRendererTestSuite) TestUnmarshalKustomizeString() {
+	var cfg release.PostRendererReference
+	str := `kustomize: ./my-kustomize`
+
+	err := yaml.Unmarshal([]byte(str), &cfg)
+
+	ts.Require().NoError(err)
+	ts.Require().Empty(cfg.Exec)
+	ts.Require().NotNil(cfg.Kustomize)
+	ts.Require().Equal("./my-kustomize", cfg.Kustomize.Src)
+}
+
+func (ts *PostRendererTestSuite) TestUnmarshalKustomizeObject() {
+	var cfg release.PostRendererReference
+	str := `
+kustomize:
+  src: ./my-kustomize
+  renderer: gomplate
+  delimiter_left: "[["
+  delimiter_right: "]]"
+`
+
+	err := yaml.Unmarshal([]byte(str), &cfg)
+
+	ts.Require().NoError(err)
+	ts.Require().Empty(cfg.Exec)
+	ts.Require().NotNil(cfg.Kustomize)
+	ts.Require().Equal("./my-kustomize", cfg.Kustomize.Src)
+	ts.Require().Equal("gomplate", cfg.Kustomize.Renderer)
+	ts.Require().Equal("[[", cfg.Kustomize.DelimiterLeft)
+	ts.Require().Equal("]]", cfg.Kustomize.DelimiterRight)
+}
+
+func (ts *PostRendererTestSuite) TestUnmarshalMutualExclusivity() {
+	var cfg release.PostRendererReference
+	str := `
+exec: "./script.sh"
+kustomize: ./my-kustomize
+`
+
+	err := yaml.Unmarshal([]byte(str), &cfg)
+
+	ts.Require().Error(err)
+	ts.Require().Contains(err.Error(), "mutually exclusive")
+}
+
+func (ts *PostRendererTestSuite) TestIsEmpty() {
+	ts.True((&release.PostRendererReference{}).IsEmpty())
+	ts.True((*release.PostRendererReference)(nil).IsEmpty())
+
+	ts.False((&release.PostRendererReference{Exec: []string{"cmd"}}).IsEmpty())
+	ts.False((&release.PostRendererReference{Kustomize: &release.KustomizeConfig{Src: "path"}}).IsEmpty())
+}
+
+func (ts *PostRendererTestSuite) TestHelmPostRendererExec() {
+	cfg := &release.PostRendererReference{Exec: []string{"/bin/sh", "-c", "cat"}}
+
+	pr, err := cfg.HelmPostRenderer()
+
+	ts.Require().NoError(err)
+	ts.Require().NotNil(pr)
+}
+
+func (ts *PostRendererTestSuite) TestHelmPostRendererKustomizeNotBuilt() {
+	cfg := &release.PostRendererReference{Kustomize: &release.KustomizeConfig{Src: "./kustomize"}}
+
+	_, err := cfg.HelmPostRenderer()
+
+	ts.Require().Error(err)
+	ts.Require().Contains(err.Error(), "not built yet")
+}
+
+func (ts *PostRendererTestSuite) TestJSONSchema() {
+	schema := release.PostRendererReference{}.JSONSchema()
+
+	ts.Require().NotNil(schema)
+	ts.Require().NotNil(schema.OneOf)
+	ts.Require().Len(schema.OneOf, 2)
+}


### PR DESCRIPTION
Closes #1189 

### Proposal

Extend `post_renderer` from `[]string` to an object format with two mutually exclusive modes:

```yaml
# exec mode
post_renderer:
  exec: "./kustomize.sh"           # string, shlex split
  # or
  exec: ["./script.sh", "--arg1"]  # array

# kustomize mode
post_renderer:
  kustomize: path/to/kustomize     # short form
  # or
  kustomize:                       # object form with options
    src: path/to/kustomize
    renderer: sprig                # sprig/gomplate
    delimiter_left: "{{"
    delimiter_right: "}}"
```

Legacy `post_renderer: ["cmd", "arg"]` array syntax remains supported, automatically converted to exec mode.

### Example

For:
```yaml
redis:
  post_renderer:
    kustomize: kustomize/redis
```

It will:
1. After building values, render all files in `kustomize/redis` to a temp directory
2. During post rendering, save the helm manifests to `all.yml`/`all.yaml` (according to the extension of `kustomization.yml`/`kustomization.yaml`, or if already specified in `kustomization.yml`) in the temp directory.
3. Perform `kustomize edit add resource all.yml/all.yaml` in the temp directory to inject helm manifests into `kustomization.yml`. This will be skipped if user has already specified `all.yml`/`all.yaml` in the kustomization file.
4. Run kustomize on the temp directory.
5. After plan built, export the kustomize directory to `.helmwave` directory.

---

It has worked quite well for my month's use.